### PR TITLE
Add CLI option to install client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.guardsquare:proguard-gradle:7.1.0'
+        classpath 'com.guardsquare:proguard-gradle:7.4.1'
     }
 }
 

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -84,8 +84,8 @@ public class SimpleInstaller
         }
 
         OptionParser parser = new OptionParser();
-        OptionSpec<File> clientInstallOption = parser.accepts("installClient", "Install a client to the specified directory, defaulting to the MC installer dir").withOptionalArg().ofType(File.class).defaultsTo(getMCDir());
-        OptionSpec<File> serverInstallOption = parser.accepts("installServer", "Install a server to the current directory").withOptionalArg().ofType(File.class).defaultsTo(new File("."));
+        OptionSpec<File> clientInstallOption = parser.acceptsAll(Arrays.asList("installClient", "install-client"), "Install a client to the specified directory, defaulting to the MC installer dir").withOptionalArg().ofType(File.class).defaultsTo(getMCDir());
+        OptionSpec<File> serverInstallOption = parser.acceptsAll(Arrays.asList("installServer", "install-server"), "Install a server to the current directory").withOptionalArg().ofType(File.class).defaultsTo(new File("."));
         OptionSpec<File> extractOption = parser.accepts("extract", "Extract the contained jar file to the specified directory").withOptionalArg().ofType(File.class).defaultsTo(new File("."));
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"),"Help with this installer");
         OptionSpec<Void> offlineOption = parser.accepts("offline", "Don't attempt any network calls");

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -84,6 +84,7 @@ public class SimpleInstaller
         }
 
         OptionParser parser = new OptionParser();
+        OptionSpec<File> clientInstallOption = parser.accepts("installClient", "Install a client to the specified directory, defaulting to the MC installer dir").withOptionalArg().ofType(File.class).defaultsTo(getMCDir());
         OptionSpec<File> serverInstallOption = parser.accepts("installServer", "Install a server to the current directory").withOptionalArg().ofType(File.class).defaultsTo(new File("."));
         OptionSpec<File> extractOption = parser.accepts("extract", "Extract the contained jar file to the specified directory").withOptionalArg().ofType(File.class).defaultsTo(new File("."));
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"),"Help with this installer");
@@ -110,8 +111,7 @@ public class SimpleInstaller
         else
         {
             for(String host : new String[] {
-                "files.minecraftforge.net",
-                "maven.minecraftforge.net",
+                "maven.neoforged.net",
                 "libraries.minecraft.net",
                 "launchermeta.mojang.com",
                 "piston-meta.mojang.com",
@@ -130,6 +130,9 @@ public class SimpleInstaller
         } else if (optionSet.has(extractOption)) {
             action = Actions.EXTRACT;
             target = optionSet.valueOf(extractOption);
+        } else if (optionSet.has(clientInstallOption)) {
+            action = Actions.CLIENT;
+            target = optionSet.valueOf(clientInstallOption);
         }
 
         if (action != null)

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -84,7 +84,7 @@ public class SimpleInstaller
         }
 
         OptionParser parser = new OptionParser();
-        OptionSpec<File> clientInstallOption = parser.acceptsAll(Arrays.asList("installClient", "install-client"), "Install a client to the specified directory, defaulting to the MC installer dir").withOptionalArg().ofType(File.class).defaultsTo(getMCDir());
+        OptionSpec<File> clientInstallOption = parser.acceptsAll(Arrays.asList("installClient", "install-client"), "Install a client to the specified directory, defaulting to the MC installation directory").withOptionalArg().ofType(File.class).defaultsTo(getMCDir());
         OptionSpec<File> serverInstallOption = parser.acceptsAll(Arrays.asList("installServer", "install-server"), "Install a server to the current directory").withOptionalArg().ofType(File.class).defaultsTo(new File("."));
         OptionSpec<File> extractOption = parser.accepts("extract", "Extract the contained jar file to the specified directory").withOptionalArg().ofType(File.class).defaultsTo(new File("."));
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"),"Help with this installer");


### PR DESCRIPTION
Add the `--install-client` CLI option that installs a client profile.  
Since Neo doesn't need to make money through ads, 3rd parties are free to automate its installation.  
This was tested by bumping the [installer version](https://github.com/neoforged/NeoGradle/blob/d78cf92278beaddc04fc78dda8d512375f92238c/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java#L451) in NeoGradle to `net.neoforged:legacyinstaller:3.0.+`.