### PR TITLE
Translation support

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,5 +8,5 @@ pull_request_labels:
   - l10n
 files:
   - source: /src/main/resources/neoforged/installer.xml
-    translation: /src/main/resources/assets/neoforge/neoforged/installer_%locale%.%file_extension%
+    translation: /src/main/resources/neoforged/installer_%locale%.%file_extension%
     dest: /messages.%file_extension%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,12 @@
+project_id_env: NEOFORGE_CROWDIN_PROJECT_ID
+api_token_env: NEOFORGE_CROWDIN_API_TOKEN
+base_path: .
+base_url: 'https://neoforged.api.crowdin.com'
+preserve_hierarchy: 1
+commit_message: '[ci skip]'
+pull_request_labels:
+  - l10n
+files:
+  - source: /src/main/resources/neoforged/installer.xml
+    translation: /src/main/resources/assets/neoforge/neoforged/installer_%locale%.%file_extension%
+    dest: /messages.%file_extension%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,5 +8,5 @@ pull_request_labels:
   - l10n
 files:
   - source: /src/main/resources/neoforged/installer.xml
-    translation: /src/main/resources/neoforged/installer_%locale%.%file_extension%
+    translation: /src/main/resources/neoforged/installer_%two_letters_code%.%file_extension%
     dest: /messages.%file_extension%

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -43,6 +43,7 @@ import net.minecraftforge.installer.actions.Actions;
 import net.minecraftforge.installer.actions.ProgressCallback;
 import net.minecraftforge.installer.json.InstallV1;
 import net.minecraftforge.installer.json.Util;
+import net.minecraftforge.installer.ui.InstallerPanel;
 import net.neoforged.cliutils.progress.ProgressInterceptor;
 import net.neoforged.cliutils.progress.ProgressManager;
 import net.neoforged.cliutils.progress.ProgressReporter;
@@ -209,7 +210,7 @@ public class SimpleInstaller
         return new BufferedOutputStream(new FileOutputStream(output));
     }
 
-    static void hookStdOut(ProgressCallback monitor)
+    public static void hookStdOut(ProgressCallback monitor)
     {
         final Pattern endingWhitespace = Pattern.compile("\\r?\\n$");
         final OutputStream monitorStream = new OutputStream() {

--- a/src/main/java/net/minecraftforge/installer/actions/Action.java
+++ b/src/main/java/net/minecraftforge/installer/actions/Action.java
@@ -34,6 +34,7 @@ import net.minecraftforge.installer.json.Util;
 import net.minecraftforge.installer.json.Version;
 import net.minecraftforge.installer.json.Version.Library;
 import net.minecraftforge.installer.json.Version.LibraryDownload;
+import net.minecraftforge.installer.ui.TranslatedMessage;
 
 public abstract class Action {
     protected final InstallV1 profile;
@@ -57,7 +58,7 @@ public abstract class Action {
 
     public abstract boolean run(File target, Predicate<String> optionals, File installer) throws ActionCanceledException;
     public abstract TargetValidator getTargetValidator();
-    public abstract String getSuccessMessage();
+    public abstract TranslatedMessage getSuccessMessage();
 
     public String getSponsorMessage() {
         return profile.getMirror() != null && profile.getMirror().isAdvertised() ? String.format(SimpleInstaller.headless ? "Data kindly mirrored by %2$s at %1$s" : "<html><a href=\'%s\'>Data kindly mirrored by %s</a></html>", profile.getMirror().getHomepage(), profile.getMirror().getName()) : null;

--- a/src/main/java/net/minecraftforge/installer/actions/Actions.java
+++ b/src/main/java/net/minecraftforge/installer/actions/Actions.java
@@ -25,9 +25,9 @@ import net.minecraftforge.installer.json.InstallV1;
 
 public enum Actions
 {
-    CLIENT("action.install.client.name", "action.install.client.tooltip", ClientInstall::new, () -> "Successfully installed client into launcher."),
-    SERVER("action.install.server.name", "action.install.server.tooltip", ServerInstall::new, () -> "The server installed successfully"),
-    EXTRACT("action.extract.name", "action.extract.tooltip", ExtractAction::new, () -> "All files successfully extract.");
+    CLIENT("installer.action.install.client.name", "installer.action.install.client.tooltip", ClientInstall::new, () -> "Successfully installed client into launcher."),
+    SERVER("installer.action.install.server.name", "installer.action.install.server.tooltip", ServerInstall::new, () -> "The server installed successfully"),
+    EXTRACT("installer.action.extract.name", "installer.action.extract.tooltip", ExtractAction::new, () -> "All files successfully extract.");
 
     private String label;
     private String tooltip;

--- a/src/main/java/net/minecraftforge/installer/actions/Actions.java
+++ b/src/main/java/net/minecraftforge/installer/actions/Actions.java
@@ -25,9 +25,9 @@ import net.minecraftforge.installer.json.InstallV1;
 
 public enum Actions
 {
-    CLIENT("Install client", "Install a new profile to the Mojang client launcher", ClientInstall::new, () -> "Successfully installed client into launcher."),
-    SERVER("Install server", "Create a new modded server installation", ServerInstall::new, () -> "The server installed successfully"),
-    EXTRACT("Extract", "Extract the contained jar file", ExtractAction::new, () -> "All files successfully extract.");
+    CLIENT("action.install.client.name", "action.install.client.tooltip", ClientInstall::new, () -> "Successfully installed client into launcher."),
+    SERVER("action.install.server.name", "action.install.server.tooltip", ServerInstall::new, () -> "The server installed successfully"),
+    EXTRACT("action.extract.name", "action.extract.tooltip", ExtractAction::new, () -> "All files successfully extract.");
 
     private String label;
     private String tooltip;

--- a/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
@@ -203,8 +203,8 @@ public class ClientInstall extends Action {
     @Override
     public TranslatedMessage getSuccessMessage() {
         if (downloadedCount() > 0) {
-            return new TranslatedMessage("action.install.client.finished.withlibs", profile.getProfile(), profile.getVersion(), downloadedCount());
+            return new TranslatedMessage("installer.action.install.client.finished.withlibs", profile.getProfile(), profile.getVersion(), downloadedCount());
         }
-        return new TranslatedMessage("action.install.client.finished.withoutlibs", profile.getProfile(), profile.getVersion());
+        return new TranslatedMessage("installer.action.install.client.finished.withoutlibs", profile.getProfile(), profile.getVersion());
     }
 }

--- a/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
@@ -31,6 +31,7 @@ import net.minecraftforge.installer.json.Version;
 import net.minecraftforge.installer.json.Version.Download;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import net.minecraftforge.installer.ui.TranslatedMessage;
 
 public class ClientInstall extends Action {
 
@@ -200,9 +201,10 @@ public class ClientInstall extends Action {
     }
 
     @Override
-    public String getSuccessMessage() {
-        if (downloadedCount() > 0)
-            return String.format("Successfully installed client profile %s for version %s into launcher, and downloaded %d libraries", profile.getProfile(), profile.getVersion(), downloadedCount());
-        return String.format("Successfully installed client profile %s for version %s into launcher", profile.getProfile(), profile.getVersion());
+    public TranslatedMessage getSuccessMessage() {
+        if (downloadedCount() > 0) {
+            return new TranslatedMessage("action.install.client.finished.withlibs", profile.getProfile(), profile.getVersion(), downloadedCount());
+        }
+        return new TranslatedMessage("action.install.client.finished.withoutlibs", profile.getProfile(), profile.getVersion());
     }
 }

--- a/src/main/java/net/minecraftforge/installer/actions/ExtractAction.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ExtractAction.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 import net.minecraftforge.installer.DownloadUtils;
 import net.minecraftforge.installer.json.Artifact;
 import net.minecraftforge.installer.json.InstallV1;
+import net.minecraftforge.installer.ui.TranslatedMessage;
 
 public class ExtractAction extends Action {
 
@@ -88,7 +89,7 @@ public class ExtractAction extends Action {
     }
 
     @Override
-    public String getSuccessMessage() {
-        return "Extracted successfully";
+    public TranslatedMessage getSuccessMessage() {
+        return new TranslatedMessage("action.extract.finished");
     }
 }

--- a/src/main/java/net/minecraftforge/installer/actions/ExtractAction.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ExtractAction.java
@@ -90,6 +90,6 @@ public class ExtractAction extends Action {
 
     @Override
     public TranslatedMessage getSuccessMessage() {
-        return new TranslatedMessage("action.extract.finished");
+        return new TranslatedMessage("installer.action.extract.finished");
     }
 }

--- a/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
@@ -32,6 +32,7 @@ import net.minecraftforge.installer.json.InstallV1;
 import net.minecraftforge.installer.json.Util;
 import net.minecraftforge.installer.json.Version;
 import net.minecraftforge.installer.json.Version.Download;
+import net.minecraftforge.installer.ui.TranslatedMessage;
 
 public class ServerInstall extends Action {
     private List<Artifact> grabbed = new ArrayList<>();
@@ -133,9 +134,10 @@ public class ServerInstall extends Action {
     }
 
     @Override
-    public String getSuccessMessage() {
-        if (!grabbed.isEmpty())
-            return String.format("Successfully downloaded minecraft server, downloaded %d libraries and installed %s", grabbed.size(), profile.getVersion());
-        return String.format("Successfully downloaded minecraft server and installed %s", profile.getVersion());
+    public TranslatedMessage getSuccessMessage() {
+        if (grabbed.isEmpty()) {
+            return new TranslatedMessage("action.install.server.finished.withoutlibs", profile.getVersion());
+        }
+        return new TranslatedMessage("action.install.server.finished.withlibs", grabbed.size(), profile.getVersion());
     }
 }

--- a/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
@@ -136,8 +136,8 @@ public class ServerInstall extends Action {
     @Override
     public TranslatedMessage getSuccessMessage() {
         if (grabbed.isEmpty()) {
-            return new TranslatedMessage("action.install.server.finished.withoutlibs", profile.getVersion());
+            return new TranslatedMessage("installer.action.install.server.finished.withoutlibs", profile.getVersion());
         }
-        return new TranslatedMessage("action.install.server.finished.withlibs", grabbed.size(), profile.getVersion());
+        return new TranslatedMessage("installer.action.install.server.finished.withlibs", grabbed.size(), profile.getVersion());
     }
 }

--- a/src/main/java/net/minecraftforge/installer/actions/TargetValidator.java
+++ b/src/main/java/net/minecraftforge/installer/actions/TargetValidator.java
@@ -40,20 +40,20 @@ public interface TargetValidator {
     }
 
     static TargetValidator isDirectory() {
-        return target -> target.isDirectory() ? ValidationResult.valid() : ValidationResult.invalid(true, "target.error.notdirectory");
+        return target -> target.isDirectory() ? ValidationResult.valid() : ValidationResult.invalid(true, "installer.target.error.notdirectory");
     }
 
     static TargetValidator shouldExist(boolean critical) {
-        return target -> target.exists() ? ValidationResult.valid() : ValidationResult.invalid(critical, critical ? "target.error.directory.doesntexist.critical" : "target.error.directory.doesntexist.create");
+        return target -> target.exists() ? ValidationResult.valid() : ValidationResult.invalid(critical, critical ? "installer.target.error.directory.doesntexist.critical" : "installer.target.error.directory.doesntexist.create");
     }
 
     static TargetValidator shouldBeEmpty() {
-        return target -> Objects.requireNonNull(target.list()).length == 0 ? ValidationResult.valid() : ValidationResult.invalid(false, "target.error.directory.notempty");
+        return target -> Objects.requireNonNull(target.list()).length == 0 ? ValidationResult.valid() : ValidationResult.invalid(false, "installer.target.error.directory.notempty");
     }
 
     static TargetValidator isMCInstallationDirectory() {
         return target -> (new File(target, "launcher_profiles.json").exists() ||
-                new File(target, "launcher_profiles_microsoft_store.json").exists()) ? ValidationResult.valid() : ValidationResult.invalid(true, "target.error.missingprofile");
+                new File(target, "launcher_profiles_microsoft_store.json").exists()) ? ValidationResult.valid() : ValidationResult.invalid(true, "installer.target.error.missingprofile");
     }
 
     class ValidationResult {

--- a/src/main/java/net/minecraftforge/installer/actions/TargetValidator.java
+++ b/src/main/java/net/minecraftforge/installer/actions/TargetValidator.java
@@ -18,6 +18,7 @@
  */
 package net.minecraftforge.installer.actions;
 
+import net.minecraftforge.installer.ui.TranslatedMessage;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -39,24 +40,24 @@ public interface TargetValidator {
     }
 
     static TargetValidator isDirectory() {
-        return target -> target.isDirectory() ? ValidationResult.valid() : ValidationResult.invalid(true, "The specified path needs to be a directory");
+        return target -> target.isDirectory() ? ValidationResult.valid() : ValidationResult.invalid(true, "target.error.notdirectory");
     }
 
     static TargetValidator shouldExist(boolean critical) {
-        return target -> target.exists() ? ValidationResult.valid() : ValidationResult.invalid(critical, "The specified directory does not exist" + (critical ? "" : "<br/>It will be created"));
+        return target -> target.exists() ? ValidationResult.valid() : ValidationResult.invalid(critical, critical ? "target.error.directory.doesntexist.critical" : "target.error.directory.doesntexist.create");
     }
 
     static TargetValidator shouldBeEmpty() {
-        return target -> Objects.requireNonNull(target.list()).length == 0 ? ValidationResult.valid() : ValidationResult.invalid(false, "There are already files in the target directory");
+        return target -> Objects.requireNonNull(target.list()).length == 0 ? ValidationResult.valid() : ValidationResult.invalid(false, "target.error.directory.notempty");
     }
 
     static TargetValidator isMCInstallationDirectory() {
         return target -> (new File(target, "launcher_profiles.json").exists() ||
-                new File(target, "launcher_profiles_microsoft_store.json").exists()) ? ValidationResult.valid() : ValidationResult.invalid(true, "The directory is missing a launcher profile. Please run the minecraft launcher first");
+                new File(target, "launcher_profiles_microsoft_store.json").exists()) ? ValidationResult.valid() : ValidationResult.invalid(true, "target.error.missingprofile");
     }
 
     class ValidationResult {
-        private static final ValidationResult VALID = new ValidationResult(true, false, "");
+        private static final ValidationResult VALID = new ValidationResult(true, false, new TranslatedMessage(""));
 
         /**
          * Whether the target directory is valid for installation.
@@ -69,9 +70,9 @@ public interface TargetValidator {
         /**
          * A message to display to users if the target is invalid.
          */
-        public final String message;
+        public final TranslatedMessage message;
 
-        private ValidationResult(boolean valid, boolean critical, String message) {
+        private ValidationResult(boolean valid, boolean critical, TranslatedMessage message) {
             this.valid = valid;
             this.critical = critical;
             this.message = message;
@@ -81,8 +82,8 @@ public interface TargetValidator {
             return VALID;
         }
 
-        public static ValidationResult invalid(boolean critical, String message) {
-            return new ValidationResult(false, critical, message);
+        public static ValidationResult invalid(boolean critical, String messageKey) {
+            return new ValidationResult(false, critical, new TranslatedMessage(messageKey));
         }
 
         public ValidationResult combine(Supplier<ValidationResult> other) {

--- a/src/main/java/net/minecraftforge/installer/ui/Images.java
+++ b/src/main/java/net/minecraftforge/installer/ui/Images.java
@@ -1,4 +1,24 @@
-package net.minecraftforge.installer;
+/*
+ * Installer
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.minecraftforge.installer.ui;
+
+import net.minecraftforge.installer.SimpleInstaller;
 
 import javax.imageio.ImageIO;
 import java.awt.Image;

--- a/src/main/java/net/minecraftforge/installer/ui/InstallerPanel.java
+++ b/src/main/java/net/minecraftforge/installer/ui/InstallerPanel.java
@@ -16,8 +16,9 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package net.minecraftforge.installer;
+package net.minecraftforge.installer.ui;
 
+import net.minecraftforge.installer.SimpleInstaller;
 import net.minecraftforge.installer.actions.Action;
 import net.minecraftforge.installer.actions.ActionCanceledException;
 import net.minecraftforge.installer.actions.Actions;
@@ -26,26 +27,9 @@ import net.minecraftforge.installer.actions.TargetValidator;
 import net.minecraftforge.installer.json.InstallV1;
 import net.minecraftforge.installer.json.OptionalLibrary;
 
-import javax.swing.AbstractAction;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JTextField;
+import javax.swing.*;
 import javax.swing.border.LineBorder;
-import java.awt.Color;
-import java.awt.Desktop;
-import java.awt.Dimension;
-import java.awt.EventQueue;
-import java.awt.Font;
-import java.awt.Insets;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -55,13 +39,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("unused")
 public class InstallerPanel extends JPanel {
+    public static final L10nManager TRANSLATIONS = new L10nManager("neoforged/installer", new File(SimpleInstaller.getMCDir(), "libraries/.neoforge_installer.properties"));
     private static final long serialVersionUID = 1L;
     private File targetDir;
     private ButtonGroup choiceButtonGroup;
@@ -143,7 +130,8 @@ public class InstallerPanel extends JPanel {
         logoLabel.setAlignmentY(CENTER_ALIGNMENT);
         logoLabel.setSize(image.getWidth(), image.getHeight());
         logoSplash.add(logoLabel);
-        JLabel tag = new JLabel(profile.getWelcome());
+        JLabel tag = new JLabel();
+        TRANSLATIONS.translate(tag, TranslationTarget.LABEL_TEXT, profile.getWelcome());
         tag.setAlignmentX(CENTER_ALIGNMENT);
         tag.setAlignmentY(CENTER_ALIGNMENT);
         logoSplash.add(tag);
@@ -151,7 +139,7 @@ public class InstallerPanel extends JPanel {
         {
             // The version is a box that has a first label that is non-bold
             final Box version = Box.createHorizontalBox();
-            version.add(new JLabel("Version: "));
+            version.add(TRANSLATIONS.label("welcome.version"));
             tag = new JLabel(profile.getVersion());
             // and a bold part which represents the actual version
             tag.setFont(tag.getFont().deriveFont(Font.BOLD));
@@ -192,11 +180,9 @@ public class InstallerPanel extends JPanel {
             if (action == Actions.SERVER && profile.hideServer()) continue;
             if (action == Actions.EXTRACT && profile.hideExtract()) continue;
             actions.put(action.name(), prog -> action.getAction(profile, prog));
-            JRadioButton radioButton = new JRadioButton();
-            radioButton.setAction(sba);
-            radioButton.setText(action.getButtonLabel());
+            JRadioButton radioButton = TRANSLATIONS.radioButton(sba, action.getButtonLabel());
+            TRANSLATIONS.setTooltip(radioButton, action.getTooltip());
             radioButton.setActionCommand(action.name());
-            radioButton.setToolTipText(action.getTooltip());
             radioButton.setSelected(first);
             radioButton.setAlignmentX(LEFT_ALIGNMENT);
             radioButton.setAlignmentY(CENTER_ALIGNMENT);
@@ -217,95 +203,19 @@ public class InstallerPanel extends JPanel {
         choicePanel.setAlignmentY(CENTER_ALIGNMENT);
         add(choicePanel);
 
-        /*
-        if (VersionInfo.hasOptionals())
-        {
-            optionals = new OptionalListEntry[VersionInfo.getOptionals().size()];
-            int x = 0;
-            for (OptionalLibrary opt : VersionInfo.getOptionals())
-                optionals[x++] = new OptionalListEntry(opt);
-
-            final JList<OptionalListEntry> list = new JList<OptionalListEntry>(optionals);
-
-            list.setCellRenderer(new ListCellRenderer<OptionalListEntry>()
-            {
-                private JPanel panel = new JPanel(new BorderLayout());
-                private JCheckBox check = new JCheckBox();
-                private JLabel icon = new JLabel(new ImageIcon(urlIcon));
-                {
-                    check.setHorizontalAlignment(SwingConstants.LEFT);
-                    icon.setSize(urlIcon.getWidth(), urlIcon.getHeight());
-                    panel.add(check, BorderLayout.LINE_START);
-                    panel.add(icon,  BorderLayout.LINE_END);
-                }
-
-                @Override
-                public Component getListCellRendererComponent(JList<? extends OptionalListEntry> list, OptionalListEntry value, int index, boolean isSelected, boolean cellHasFocus)
-                {
-                    check.setSelected(value.isEnabled());
-                    check.setText(value.lib.getName());
-                    icon.setVisible(value.lib.getURL() != null);
-                    return panel;
-                }
-            });
-
-            list.addMouseListener(new MouseAdapter()
-            {
-                public void mouseClicked(MouseEvent event)
-                {
-                    int index = list.locationToIndex(event.getPoint());
-                    OptionalListEntry entry = list.getModel().getElementAt(index);
-
-                    if (entry.lib.getURL() != null && event.getPoint().getX() > list.getWidth() - urlIcon.getWidth())
-                        openURL(entry.lib.getURL());
-                    else
-                        entry.setEnabled(!entry.isEnabled());
-                    list.repaint(list.getCellBounds(index, index));
-                }
-            });
-            list.addMouseMotionListener(new MouseMotionListener()
-            {
-                public void mouseMoved(MouseEvent event)
-                {
-                    int index = list.locationToIndex(event.getPoint());
-                    OptionalListEntry entry = list.getModel().getElementAt(index);
-                    if (entry.lib.getDesc() != null)
-                    {
-                        StringBuilder tt = new StringBuilder();
-                        tt.append("<html>");
-                        //tt.append("  <h1>").append(index).append(" ").append(entry.lib.getName()).append("</h1>");
-                        //if (entry.lib.getURL() != null)
-                        //    tt.append("  URL: <a href=\"").append(entry.lib.getURL()).append("\">").append(entry.lib.getURL()).append("</a><br />");
-                        if (entry.lib.getDesc() != null)
-                            tt.append(entry.lib.getDesc());
-                        tt.append("</html>");
-                        list.setToolTipText(tt.toString());
-                    }
-                    else
-                        list.setToolTipText(null);
-                }
-
-                @Override public void mouseDragged(MouseEvent event) {}
-            });
-
-
-            add(new JScrollPane(list));
-        }
-        */
-
         JPanel entryPanel = new JPanel();
         entryPanel.setLayout(new BoxLayout(entryPanel,BoxLayout.X_AXIS));
 
         this.targetDir = targetDir;
         selectedDirText = new JTextField();
         selectedDirText.setEditable(false);
-        selectedDirText.setToolTipText("Path to the Minecraft installation directory");
+        TRANSLATIONS.setTooltip(selectedDirText, "welcome.target.tooltip");
         selectedDirText.setColumns(30);
         entryPanel.add(selectedDirText);
         JButton dirSelect = new JButton();
         dirSelect.setAction(new FileSelectAction());
         dirSelect.setText("...");
-        dirSelect.setToolTipText("Select an alternative Minecraft directory");
+        TRANSLATIONS.setTooltip(dirSelect, "welcome.dirselect.tooltip");
         entryPanel.add(dirSelect);
 
         entryPanel.setAlignmentX(LEFT_ALIGNMENT);
@@ -368,7 +278,7 @@ public class InstallerPanel extends JPanel {
         } else {
             selectedDirText.setForeground(Color.RED);
             fileEntryPanel.setBorder(new LineBorder(Color.RED));
-            infoLabel.setText("<html>"+valid.message+"</html>");
+            TRANSLATIONS.translate(infoLabel, TranslationTarget.html(TranslationTarget.LABEL_TEXT), valid.message.key, valid.message.arguments);
             infoLabel.setVisible(true);
             proceedButton.ifPresent(button -> button.setEnabled(!valid.critical));
         }
@@ -382,25 +292,41 @@ public class InstallerPanel extends JPanel {
 
     public void run(ProgressCallback monitor)
     {
-        JOptionPane optionPane = new JOptionPane(this, JOptionPane.PLAIN_MESSAGE, JOptionPane.OK_CANCEL_OPTION);
+        final JComboBox<L10nManager.LocaleSelection> languageBox = new JComboBox<>();
+
+        final List<L10nManager.LocaleSelection> known = TRANSLATIONS.getKnownLocales();
+        languageBox.setModel(new DefaultComboBoxModel(known.toArray()));
+
+        final Locale current = TRANSLATIONS.getLocale();
+        languageBox.setSelectedItem(known.stream().filter(locate -> locate.locale.equals(current)).findFirst().orElse(known.get(0)));
+        languageBox.addActionListener(e -> TRANSLATIONS.setLocale(((L10nManager.LocaleSelection)languageBox.getSelectedItem()).locale, true));
+
+        JOptionPane optionPane = new JOptionPane(this, JOptionPane.PLAIN_MESSAGE, JOptionPane.OK_CANCEL_OPTION, null, new Object[] {
+                TRANSLATIONS.button("button.proceed"), TRANSLATIONS.button("button.cancel"), languageBox
+        });
 
         // Attempt to change the OK button to a Proceed button
         // Use index 1 (the buttons panel) as 0 is this panel
-        proceedButton = Arrays.stream(((JPanel) optionPane.getComponents()[1]).getComponents())
+        final JPanel buttonPanel = (JPanel) optionPane.getComponents()[1];
+        final List<JButton> buttons = Arrays.stream(buttonPanel.getComponents())
                 .filter(comp -> comp instanceof JButton)
                 .map(JButton.class::cast)
-                .filter(btn -> btn.getText().equals("OK"))
-                .findFirst();
-        proceedButton.ifPresent(button -> button.setText("Proceed"));
+                .collect(Collectors.toList());
+        if (buttons.size() == 2) {
+            proceedButton = Optional.of(buttons.get(0));
+            buttons.get(0).addActionListener(e -> optionPane.setValue(JOptionPane.OK_OPTION));
+            buttons.get(1).addActionListener(e -> optionPane.setValue(JOptionPane.OK_CANCEL_OPTION));
+        }
 
-        dialog = optionPane.createDialog("NeoForge installer");
+        dialog = optionPane.createDialog("");
+        TRANSLATIONS.translate(dialog, new TranslationTarget<>(Dialog::setTitle), "window.title", profile.getProfile());
         dialog.setIconImages(Images.getWindowIcons());
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
         dialog.setVisible(true);
         int result = (Integer) (optionPane.getValue() != null ? optionPane.getValue() : -1);
         if (result == JOptionPane.OK_OPTION)
         {
-            ProgressFrame prog = new ProgressFrame(monitor, "Installing " + profile.getVersion(), Thread.currentThread()::interrupt);
+            ProgressFrame prog = new ProgressFrame(monitor, Thread.currentThread()::interrupt, "frame.installing", profile.getProfile(), profile.getVersion());
             SimpleInstaller.hookStdOut(prog);
             Predicate<String> optPred = input -> {
                 Optional<OptionalListEntry> ent = this.optionals.stream().filter(e -> e.lib.getArtifact().equals(input)).findFirst();
@@ -413,10 +339,10 @@ public class InstallerPanel extends JPanel {
                 if (action.run(targetDir, optPred, installer)) {
                     prog.start("Finished!");
                     prog.getGlobalProgress().percentageProgress(1);
-                    JOptionPane.showMessageDialog(null, action.getSuccessMessage(), "Complete", JOptionPane.INFORMATION_MESSAGE);
+                    JOptionPane.showMessageDialog(null, TRANSLATIONS.translate(action.getSuccessMessage()), TRANSLATIONS.translate("installation.complete"), JOptionPane.INFORMATION_MESSAGE);
                 }
             } catch (ActionCanceledException e) {
-                JOptionPane.showMessageDialog(null, "Installation Canceled", "Forge Installer", JOptionPane.WARNING_MESSAGE);
+                JOptionPane.showMessageDialog(null, TRANSLATIONS.translate("installation.cancelled"), dialog.getTitle(), JOptionPane.WARNING_MESSAGE);
             } catch (Exception e) {
                 JOptionPane.showMessageDialog(null, "There was an exception running task: " + e.toString(), "Error", JOptionPane.ERROR_MESSAGE);
                 e.printStackTrace();
@@ -424,6 +350,8 @@ public class InstallerPanel extends JPanel {
                 prog.dispose();
                 SimpleInstaller.hookStdOut(monitor);
             }
+        } else if (result == JOptionPane.OK_CANCEL_OPTION) {
+            System.exit(0);
         }
         dialog.dispose();
     }

--- a/src/main/java/net/minecraftforge/installer/ui/InstallerPanel.java
+++ b/src/main/java/net/minecraftforge/installer/ui/InstallerPanel.java
@@ -35,6 +35,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -48,7 +49,9 @@ import java.util.stream.Collectors;
 
 @SuppressWarnings("unused")
 public class InstallerPanel extends JPanel {
-    public static final L10nManager TRANSLATIONS = new L10nManager("neoforged/installer", new File(SimpleInstaller.getMCDir(), "libraries/.neoforge_installer.properties"));
+    private static final Path INSTALLER_SETTINGS = new File(SimpleInstaller.getMCDir(), "libraries/.neoforge_installer.properties").toPath();
+    public static final L10nManager TRANSLATIONS = new L10nManager("neoforged/installer", INSTALLER_SETTINGS);
+
     private static final long serialVersionUID = 1L;
     private File targetDir;
     private ButtonGroup choiceButtonGroup;

--- a/src/main/java/net/minecraftforge/installer/ui/InstallerPanel.java
+++ b/src/main/java/net/minecraftforge/installer/ui/InstallerPanel.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 
 @SuppressWarnings("unused")
 public class InstallerPanel extends JPanel {
-    private static final Path INSTALLER_SETTINGS = new File(SimpleInstaller.getMCDir(), "libraries/.neoforge_installer.properties").toPath();
+    private static final Path INSTALLER_SETTINGS = new File(SimpleInstaller.getMCDir(), ".neoforge_installer.properties").toPath();
     public static final L10nManager TRANSLATIONS = new L10nManager("neoforged/installer", INSTALLER_SETTINGS);
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/net/minecraftforge/installer/ui/InstallerPanel.java
+++ b/src/main/java/net/minecraftforge/installer/ui/InstallerPanel.java
@@ -139,7 +139,7 @@ public class InstallerPanel extends JPanel {
         {
             // The version is a box that has a first label that is non-bold
             final Box version = Box.createHorizontalBox();
-            version.add(TRANSLATIONS.label("welcome.version"));
+            version.add(TRANSLATIONS.label("installer.welcome.version"));
             tag = new JLabel(profile.getVersion());
             // and a bold part which represents the actual version
             tag.setFont(tag.getFont().deriveFont(Font.BOLD));
@@ -209,13 +209,13 @@ public class InstallerPanel extends JPanel {
         this.targetDir = targetDir;
         selectedDirText = new JTextField();
         selectedDirText.setEditable(false);
-        TRANSLATIONS.setTooltip(selectedDirText, "welcome.target.tooltip");
+        TRANSLATIONS.setTooltip(selectedDirText, "installer.welcome.target.tooltip");
         selectedDirText.setColumns(30);
         entryPanel.add(selectedDirText);
         JButton dirSelect = new JButton();
         dirSelect.setAction(new FileSelectAction());
         dirSelect.setText("...");
-        TRANSLATIONS.setTooltip(dirSelect, "welcome.dirselect.tooltip");
+        TRANSLATIONS.setTooltip(dirSelect, "installer.welcome.dirselect.tooltip");
         entryPanel.add(dirSelect);
 
         entryPanel.setAlignmentX(LEFT_ALIGNMENT);
@@ -302,7 +302,7 @@ public class InstallerPanel extends JPanel {
         languageBox.addActionListener(e -> TRANSLATIONS.setLocale(((L10nManager.LocaleSelection)languageBox.getSelectedItem()).locale, true));
 
         JOptionPane optionPane = new JOptionPane(this, JOptionPane.PLAIN_MESSAGE, JOptionPane.OK_CANCEL_OPTION, null, new Object[] {
-                TRANSLATIONS.button("button.proceed"), TRANSLATIONS.button("button.cancel"), languageBox
+                TRANSLATIONS.button("installer.button.proceed"), TRANSLATIONS.button("installer.button.cancel"), languageBox
         });
 
         // Attempt to change the OK button to a Proceed button
@@ -319,14 +319,14 @@ public class InstallerPanel extends JPanel {
         }
 
         dialog = optionPane.createDialog("");
-        TRANSLATIONS.translate(dialog, new TranslationTarget<>(Dialog::setTitle), "window.title", profile.getProfile());
+        TRANSLATIONS.translate(dialog, new TranslationTarget<>(Dialog::setTitle), "installer.window.title", profile.getProfile());
         dialog.setIconImages(Images.getWindowIcons());
         dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
         dialog.setVisible(true);
         int result = (Integer) (optionPane.getValue() != null ? optionPane.getValue() : -1);
         if (result == JOptionPane.OK_OPTION)
         {
-            ProgressFrame prog = new ProgressFrame(monitor, Thread.currentThread()::interrupt, "frame.installing", profile.getProfile(), profile.getVersion());
+            ProgressFrame prog = new ProgressFrame(monitor, Thread.currentThread()::interrupt, "installer.frame.installing", profile.getProfile(), profile.getVersion());
             SimpleInstaller.hookStdOut(prog);
             Predicate<String> optPred = input -> {
                 Optional<OptionalListEntry> ent = this.optionals.stream().filter(e -> e.lib.getArtifact().equals(input)).findFirst();
@@ -339,10 +339,10 @@ public class InstallerPanel extends JPanel {
                 if (action.run(targetDir, optPred, installer)) {
                     prog.start("Finished!");
                     prog.getGlobalProgress().percentageProgress(1);
-                    JOptionPane.showMessageDialog(null, TRANSLATIONS.translate(action.getSuccessMessage()), TRANSLATIONS.translate("installation.complete"), JOptionPane.INFORMATION_MESSAGE);
+                    JOptionPane.showMessageDialog(null, TRANSLATIONS.translate(action.getSuccessMessage()), TRANSLATIONS.translate("installer.installation.complete"), JOptionPane.INFORMATION_MESSAGE);
                 }
             } catch (ActionCanceledException e) {
-                JOptionPane.showMessageDialog(null, TRANSLATIONS.translate("installation.cancelled"), dialog.getTitle(), JOptionPane.WARNING_MESSAGE);
+                JOptionPane.showMessageDialog(null, TRANSLATIONS.translate("installer.installation.cancelled"), dialog.getTitle(), JOptionPane.WARNING_MESSAGE);
             } catch (Exception e) {
                 JOptionPane.showMessageDialog(null, "There was an exception running task: " + e.toString(), "Error", JOptionPane.ERROR_MESSAGE);
                 e.printStackTrace();

--- a/src/main/java/net/minecraftforge/installer/ui/L10nManager.java
+++ b/src/main/java/net/minecraftforge/installer/ui/L10nManager.java
@@ -52,7 +52,7 @@ import java.util.ResourceBundle;
 import java.util.Set;
 
 public class L10nManager {
-    public static final ResourceBundle.Control CONTROL = new ResourceBundle.Control() {
+    private static final ResourceBundle.Control CONTROL = new ResourceBundle.Control() {
         @Override
         public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader, boolean reload) throws IllegalAccessException, InstantiationException, IOException {
             if (format.equals("java.class")) {
@@ -61,9 +61,12 @@ public class L10nManager {
                 throw new IllegalArgumentException("unknown format: " + format);
             }
 
+            // Copied from the javadocs of ResourceBundle.Control
             final String bundleName = toBundleName(baseName, locale);
 
-            if (bundleName.contains("://")) return null;
+            if (bundleName.contains("://")) {
+                return null;
+            }
             final String resourceName = toResourceName(bundleName, "xml");
 
             InputStream is = null;
@@ -82,7 +85,10 @@ public class L10nManager {
                 is = loader.getResourceAsStream(resourceName);
             }
 
-            if (is == null) return null;
+            if (is == null) {
+                return null;
+            }
+
             try (final InputStream i = is) {
                 final Properties props = new Properties();
                 props.loadFromXML(i);
@@ -117,13 +123,13 @@ public class L10nManager {
     private final Path settingsFile;
     private final List<LocaleSelection> known;
 
-    public L10nManager(String bundleName, File settingsFileIn) {
+    public L10nManager(String bundleName, Path settingsFile) {
         this.bundleName = bundleName;
-        this.settingsFile = settingsFileIn.toPath();
+        this.settingsFile = settingsFile;
         this.known = Collections.unmodifiableList(computeKnownLocales());
 
-        if (Files.exists(settingsFile)) {
-            try (final InputStream is = Files.newInputStream(settingsFile)) {
+        if (Files.exists(this.settingsFile)) {
+            try (final InputStream is = Files.newInputStream(this.settingsFile)) {
                 final Properties props = new Properties();
                 props.load(is);
                 final String lang = props.getProperty("language");
@@ -265,7 +271,7 @@ public class L10nManager {
         }
     }
 
-    public static final class MergedEnumeration implements Enumeration<String> {
+    private static final class MergedEnumeration implements Enumeration<String> {
 
         private final Set<String> set;
         private final Iterator<String> iterator;

--- a/src/main/java/net/minecraftforge/installer/ui/L10nManager.java
+++ b/src/main/java/net/minecraftforge/installer/ui/L10nManager.java
@@ -1,0 +1,301 @@
+/*
+ * Installer
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.minecraftforge.installer.ui;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JRadioButton;
+import java.awt.Component;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+import java.util.ResourceBundle;
+import java.util.Set;
+
+public class L10nManager {
+    public static final ResourceBundle.Control CONTROL = new ResourceBundle.Control() {
+        @Override
+        public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader, boolean reload) throws IllegalAccessException, InstantiationException, IOException {
+            if (format.equals("java.class")) {
+                return super.newBundle(baseName, locale, format, loader, reload);
+            } else if (!format.equals("java.properties")) {
+                throw new IllegalArgumentException("unknown format: " + format);
+            }
+
+            final String bundleName = toBundleName(baseName, locale);
+
+            if (bundleName.contains("://")) return null;
+            final String resourceName = toResourceName(bundleName, "xml");
+
+            InputStream is = null;
+            if (reload) {
+                URL url = loader.getResource(resourceName);
+                if (url != null) {
+                    URLConnection connection = url.openConnection();
+                    if (connection != null) {
+                        // Disable caches to get fresh data for
+                        // reloading.
+                        connection.setUseCaches(false);
+                        is = connection.getInputStream();
+                    }
+                }
+            } else {
+                is = loader.getResourceAsStream(resourceName);
+            }
+
+            if (is == null) return null;
+            try (final InputStream i = is) {
+                final Properties props = new Properties();
+                props.loadFromXML(i);
+                final Map<String, Object> lookup = new HashMap(props);
+                return new ResourceBundle() {
+
+                    @Override
+                    protected Object handleGetObject(@NotNull String key) {
+                        return lookup.get(key);
+                    }
+
+                    @NotNull
+                    @Override
+                    public Enumeration<String> getKeys() {
+                        return new MergedEnumeration(lookup.keySet(), (parent != null) ? parent.getKeys() : null);
+                    }
+
+                    @NotNull
+                    @Override
+                    protected Set<String> handleKeySet() {
+                        return lookup.keySet();
+                    }
+                };
+            }
+        }
+    };
+
+    private final Map<Component, Map<TranslationTarget<?>, PropertyChangeListener>> components = new IdentityHashMap<>();
+    private Locale locale;
+    private ResourceBundle bundle;
+    private final String bundleName;
+    private final Path settingsFile;
+    private final List<LocaleSelection> known;
+
+    public L10nManager(String bundleName, File settingsFileIn) {
+        this.bundleName = bundleName;
+        this.settingsFile = settingsFileIn.toPath();
+        this.known = Collections.unmodifiableList(computeKnownLocales());
+
+        if (Files.exists(settingsFile)) {
+            try (final InputStream is = Files.newInputStream(settingsFile)) {
+                final Properties props = new Properties();
+                props.load(is);
+                final String lang = props.getProperty("language");
+                if (lang == null) {
+                    setDefaultLocale();
+                } else {
+                    setLocale(Locale.forLanguageTag(lang), false);
+                }
+            } catch (Exception exception) {
+                System.err.println("Failed to read settings file: " + exception);
+                setDefaultLocale();
+            }
+        } else {
+            setDefaultLocale();
+        }
+    }
+
+    private void setDefaultLocale() {
+        final String expected = Locale.getDefault().toLanguageTag();
+        setLocale(known.stream().filter(se -> se.locale.toLanguageTag().equals(expected))
+                .findFirst().map(l -> l.locale).orElse(Locale.ENGLISH), false);
+    }
+
+    public JButton button(String key, Object... args) {
+        return translate(new JButton(), TranslationTarget.BUTTON_TEXT, key, args);
+    }
+
+    public JLabel label(String key, Object... args) {
+        return translate(new JLabel(), TranslationTarget.LABEL_TEXT, key, args);
+    }
+
+    public JRadioButton radioButton(AbstractAction action, String key, Object... args) {
+        final JRadioButton button = new JRadioButton();
+        button.setAction(action);
+        return translate(button, TranslationTarget.BUTTON_TEXT, key, args);
+    }
+
+    public <T extends JComponent> T setTooltip(T component, String key, Object... args) {
+        return translate(component, TranslationTarget.TOOLTIP, key, args);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends Component> T translate(T component, TranslationTarget<? super T> target, String key, Object... args) {
+        final Map<TranslationTarget<? super T>, PropertyChangeListener> listeners = (Map) components.computeIfAbsent(component, k -> new HashMap());
+        if (listeners.containsKey(target)) {
+            component.removePropertyChangeListener(listeners.get(target));
+        }
+        final PropertyChangeListener pcl = evt -> target.setter.accept(component, translate(key, args));
+        component.addPropertyChangeListener("locale", pcl);
+        if (component.getLocale().equals(locale)) {
+            target.setter.accept(component, translate(key, args));
+        } else {
+            component.setLocale(locale);
+        }
+        listeners.put(target, pcl);
+        return component;
+    }
+
+    public synchronized String translate(String key, Object... args) {
+        try {
+            return String.format(bundle.getString(key), args);
+        } catch (MissingResourceException ignored) {
+            return String.format(key, args);
+        }
+    }
+
+    public String translate(TranslatedMessage message) {
+        return translate(message.key, message.arguments);
+    }
+
+    public synchronized void setLocale(Locale locale, boolean write) {
+        this.locale = locale;
+        this.bundle = ResourceBundle.getBundle(bundleName, locale, CONTROL);
+
+        components.keySet().forEach(comp -> comp.setLocale(locale));
+
+        if (write) {
+            try {
+                Files.createDirectories(settingsFile.getParent());
+                try (final OutputStream os = Files.newOutputStream(settingsFile)) {
+                    final Properties props = new Properties();
+                    props.put("language", locale.toLanguageTag());
+                    props.store(os, "NeoForge installer settings file");
+                }
+                Files.setAttribute(settingsFile, "dos:hidden", true);
+            } catch (Exception exception) {
+                System.err.println("Failed to write settings file: " + exception);
+            }
+        }
+    }
+
+    public synchronized Locale getLocale() {
+        return locale;
+    }
+
+    public List<LocaleSelection> getKnownLocales() {
+        return known;
+    }
+
+    private List<LocaleSelection> computeKnownLocales() {
+        try {
+            final List<LocaleSelection> selections = new ArrayList<>();
+            for (final Locale locale : Locale.getAvailableLocales()) {
+                final InputStream is = L10nManager.class.getResourceAsStream("/" + CONTROL.toBundleName(bundleName, locale) + ".xml");
+                if (is != null) {
+                    try {
+                        final Properties properties = new Properties();
+                        properties.loadFromXML(is);
+                        selections.add(new LocaleSelection(locale, properties.getProperty("language.name")));
+                    } finally {
+                        is.close();
+                    }
+                }
+            }
+            return selections;
+        } catch (Exception exception) {
+            throw new RuntimeException("Failed to read languages: " + exception.getMessage(), exception);
+        }
+    }
+
+    public static final class LocaleSelection {
+        public final Locale locale;
+        public final String name;
+
+        private LocaleSelection(Locale locale, String name) {
+            this.locale = locale;
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    public static final class MergedEnumeration implements Enumeration<String> {
+
+        private final Set<String> set;
+        private final Iterator<String> iterator;
+        private final Enumeration<String> enumeration;
+
+        public MergedEnumeration(Set<String> set, Enumeration<String> enumeration) {
+            this.set = set;
+            this.iterator = set.iterator();
+            this.enumeration = enumeration;
+        }
+
+        String next = null;
+
+        public boolean hasMoreElements() {
+            if (next == null) {
+                if (iterator.hasNext()) {
+                    next = iterator.next();
+                } else if (enumeration != null) {
+                    while (next == null && enumeration.hasMoreElements()) {
+                        next = enumeration.nextElement();
+                        if (set.contains(next)) {
+                            next = null;
+                        }
+                    }
+                }
+            }
+            return next != null;
+        }
+
+        public String nextElement() {
+            if (hasMoreElements()) {
+                String result = next;
+                next = null;
+                return result;
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/installer/ui/L10nManager.java
+++ b/src/main/java/net/minecraftforge/installer/ui/L10nManager.java
@@ -233,7 +233,8 @@ public class L10nManager {
                     try {
                         final Properties properties = new Properties();
                         properties.loadFromXML(is);
-                        final String name = properties.getProperty("installer.language.name");
+                        String name = locale.equals(Locale.ROOT) ? "english" : locale.getDisplayName(locale);
+                        name = Character.toUpperCase(name.charAt(0)) + name.substring(1);
                         // Only root can be named English
                         if (names.add(name) && (!name.equals("English") || locale.equals(Locale.ROOT))) {
                             selections.add(new LocaleSelection(locale, name));

--- a/src/main/java/net/minecraftforge/installer/ui/L10nManager.java
+++ b/src/main/java/net/minecraftforge/installer/ui/L10nManager.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -224,6 +225,7 @@ public class L10nManager {
 
     private List<LocaleSelection> computeKnownLocales() {
         try {
+            final Set<String> names = new HashSet<>();
             final List<LocaleSelection> selections = new ArrayList<>();
             for (final Locale locale : Locale.getAvailableLocales()) {
                 final InputStream is = L10nManager.class.getResourceAsStream("/" + CONTROL.toBundleName(bundleName, locale) + ".xml");
@@ -231,7 +233,11 @@ public class L10nManager {
                     try {
                         final Properties properties = new Properties();
                         properties.loadFromXML(is);
-                        selections.add(new LocaleSelection(locale, properties.getProperty("language.name")));
+                        final String name = properties.getProperty("installer.language.name");
+                        // Only root can be named English
+                        if (names.add(name) && (!name.equals("English") || locale.equals(Locale.ROOT))) {
+                            selections.add(new LocaleSelection(locale, name));
+                        }
                     } finally {
                         is.close();
                     }

--- a/src/main/java/net/minecraftforge/installer/ui/ProgressFrame.java
+++ b/src/main/java/net/minecraftforge/installer/ui/ProgressFrame.java
@@ -88,7 +88,7 @@ public class ProgressFrame extends JFrame implements ProgressCallback
         gbc_stepProgress.gridy = gridY++;
         panel.add(stepProgress, gbc_stepProgress);
 
-        JButton btnCancel = InstallerPanel.TRANSLATIONS.button("button.cancel");
+        JButton btnCancel = InstallerPanel.TRANSLATIONS.button("installer.button.cancel");
         btnCancel.addActionListener(e -> {
             canceler.run();
             ProgressFrame.this.dispose();

--- a/src/main/java/net/minecraftforge/installer/ui/ProgressFrame.java
+++ b/src/main/java/net/minecraftforge/installer/ui/ProgressFrame.java
@@ -16,21 +16,14 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package net.minecraftforge.installer;
+package net.minecraftforge.installer.ui;
 
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 
-import javax.swing.JButton;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JProgressBar;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-import javax.swing.WindowConstants;
+import javax.swing.*;
 
 import net.minecraftforge.installer.actions.ProgressCallback;
 
@@ -49,14 +42,14 @@ public class ProgressFrame extends JFrame implements ProgressCallback
     private final ProgressBar stepProgressController;
     private final JTextArea consoleArea;
 
-    public ProgressFrame(ProgressCallback parent, String title, Runnable canceler)
+    public ProgressFrame(ProgressCallback parent, Runnable canceler, String titleKey, Object... titleArgs)
     {
         int gridY = 0;
 
         this.parent = parent;
         
         setResizable(false);
-        setTitle(title);
+        InstallerPanel.TRANSLATIONS.translate(this, new TranslationTarget<>(JFrame::setTitle), titleKey, titleArgs);
         setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         setBounds(100, 100, 600, 400);
         setContentPane(panel);
@@ -95,9 +88,8 @@ public class ProgressFrame extends JFrame implements ProgressCallback
         gbc_stepProgress.gridy = gridY++;
         panel.add(stepProgress, gbc_stepProgress);
 
-        JButton btnCancel = new JButton("Cancel");
-        btnCancel.addActionListener(e ->
-        {
+        JButton btnCancel = InstallerPanel.TRANSLATIONS.button("button.cancel");
+        btnCancel.addActionListener(e -> {
             canceler.run();
             ProgressFrame.this.dispose();
         });

--- a/src/main/java/net/minecraftforge/installer/ui/TranslatedMessage.java
+++ b/src/main/java/net/minecraftforge/installer/ui/TranslatedMessage.java
@@ -1,0 +1,29 @@
+/*
+ * Installer
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.minecraftforge.installer.ui;
+
+public class TranslatedMessage {
+    final String key;
+    final Object[] arguments;
+
+    public TranslatedMessage(String key, Object... arguments) {
+        this.key = key;
+        this.arguments = arguments;
+    }
+}

--- a/src/main/java/net/minecraftforge/installer/ui/TranslationTarget.java
+++ b/src/main/java/net/minecraftforge/installer/ui/TranslationTarget.java
@@ -1,0 +1,44 @@
+/*
+ * Installer
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.minecraftforge.installer.ui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+public final class TranslationTarget<J extends Component> {
+    public static final TranslationTarget<JLabel> LABEL_TEXT = new TranslationTarget<>(JLabel::setText);
+    public static final TranslationTarget<AbstractButton> BUTTON_TEXT = new TranslationTarget<>(AbstractButton::setText);
+    public static final TranslationTarget<JComponent> TOOLTIP = new TranslationTarget<>(JComponent::setToolTipText);
+
+    private static final Map<TranslationTarget, TranslationTarget> HTML_TARGETS = new IdentityHashMap<>();
+
+    public static <J extends Component> TranslationTarget<J> html(TranslationTarget<J> target) {
+        return (TranslationTarget<J>) HTML_TARGETS.computeIfAbsent(target, k -> new TranslationTarget((c, s) -> k.setter.accept(c, "<html>" + s + "</html>")));
+    }
+
+    final BiConsumer<? super J, String> setter;
+
+    public TranslationTarget(BiConsumer<J, String> setter) {
+        this.setter = setter;
+    }
+}

--- a/src/main/resources/neoforged/installer.xml
+++ b/src/main/resources/neoforged/installer.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-    <entry key="installer.language.name">English</entry>
-
     <entry key="installer.welcome.version">Version: </entry>
     <entry key="installer.welcome.target.tooltip">Path to the Minecraft installation directory</entry>
     <entry key="installer.welcome.dirselect.tooltip">Select an alternative Minecraft directory</entry>

--- a/src/main/resources/neoforged/installer.xml
+++ b/src/main/resources/neoforged/installer.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+    <entry key="language.name">English</entry>
+
+    <entry key="welcome.version">Version: </entry>
+    <entry key="welcome.target.tooltip">Path to the Minecraft installation directory</entry>
+    <entry key="welcome.dirselect.tooltip">Select an alternative Minecraft directory</entry>
+
+    <entry key="button.proceed">Proceed</entry>
+    <entry key="button.cancel">Cancel</entry>
+
+    <entry key="action.install.client.name">Install client</entry>
+    <entry key="action.install.client.tooltip">Install a new profile to the Mojang client launcher</entry>
+    <entry key="action.install.client.finished.withoutlibs">Successfully installed client profile %s for version %s into launcher</entry>
+    <entry key="action.install.client.finished.withlibs">Successfully installed client profile %s for version %s into launcher, and downloaded %d libraries</entry>
+
+    <entry key="action.install.server.name">Install server</entry>
+    <entry key="action.install.server.tooltip">Create a new modded server installation</entry>
+    <entry key="action.install.server.finished.withoutlibs">Successfully downloaded minecraft server and installed %s</entry>
+    <entry key="action.install.server.finished.withlibs">Successfully downloaded minecraft server, downloaded %d libraries and installed %s</entry>
+
+    <entry key="action.extract.name">Extract</entry>
+    <entry key="action.extract.tooltip">Extract the contained jar file</entry>
+    <entry key="action.extract.finished">Extracted successfully</entry>
+
+    <entry key="window.title">%s Installer</entry>
+    <entry key="frame.installing">Installing %s version %s</entry>
+
+    <entry key="installation.complete">Installation Complete</entry>
+    <entry key="installation.cancelled">Installation Cancelled</entry>
+
+    <entry key="target.error.notdirectory">The specified path needs to be a directory</entry>
+    <entry key="target.error.directory.notempty">There are already files in the target directory</entry>
+    <entry key="target.error.directory.doesntexist.critical">The specified directory does not exist</entry>
+    <entry key="target.error.directory.doesntexist.create">The specified directory does not exist&lt;br&gt;It will be created</entry>
+    <entry key="target.error.missingprofile">The directory is missing a launcher profile. Please run the Minecraft launcher first</entry>
+</properties>

--- a/src/main/resources/neoforged/installer.xml
+++ b/src/main/resources/neoforged/installer.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-    <entry key="language.name">English</entry>
+    <entry key="installer.language.name">English</entry>
 
-    <entry key="welcome.version">Version: </entry>
-    <entry key="welcome.target.tooltip">Path to the Minecraft installation directory</entry>
-    <entry key="welcome.dirselect.tooltip">Select an alternative Minecraft directory</entry>
+    <entry key="installer.welcome.version">Version: </entry>
+    <entry key="installer.welcome.target.tooltip">Path to the Minecraft installation directory</entry>
+    <entry key="installer.welcome.dirselect.tooltip">Select an alternative Minecraft directory</entry>
 
-    <entry key="button.proceed">Proceed</entry>
-    <entry key="button.cancel">Cancel</entry>
+    <entry key="installer.button.proceed">Proceed</entry>
+    <entry key="installer.button.cancel">Cancel</entry>
 
-    <entry key="action.install.client.name">Install client</entry>
-    <entry key="action.install.client.tooltip">Install a new profile to the Mojang client launcher</entry>
-    <entry key="action.install.client.finished.withoutlibs">Successfully installed client profile %s for version %s into launcher</entry>
-    <entry key="action.install.client.finished.withlibs">Successfully installed client profile %s for version %s into launcher, and downloaded %d libraries</entry>
+    <entry key="installer.action.install.client.name">Install client</entry>
+    <entry key="installer.action.install.client.tooltip">Install a new profile to the Mojang client launcher</entry>
+    <entry key="installer.action.install.client.finished.withoutlibs">Successfully installed client profile %s for version %s into launcher</entry>
+    <entry key="installer.action.install.client.finished.withlibs">Successfully installed client profile %s for version %s into launcher, and downloaded %d libraries</entry>
 
-    <entry key="action.install.server.name">Install server</entry>
-    <entry key="action.install.server.tooltip">Create a new modded server installation</entry>
-    <entry key="action.install.server.finished.withoutlibs">Successfully downloaded minecraft server and installed %s</entry>
-    <entry key="action.install.server.finished.withlibs">Successfully downloaded minecraft server, downloaded %d libraries and installed %s</entry>
+    <entry key="installer.action.install.server.name">Install server</entry>
+    <entry key="installer.action.install.server.tooltip">Create a new modded server installation</entry>
+    <entry key="installer.action.install.server.finished.withoutlibs">Successfully downloaded minecraft server and installed %s</entry>
+    <entry key="installer.action.install.server.finished.withlibs">Successfully downloaded minecraft server, downloaded %d libraries and installed %s</entry>
 
-    <entry key="action.extract.name">Extract</entry>
-    <entry key="action.extract.tooltip">Extract the contained jar file</entry>
-    <entry key="action.extract.finished">Extracted successfully</entry>
+    <entry key="installer.action.extract.name">Extract</entry>
+    <entry key="installer.action.extract.tooltip">Extract the contained jar file</entry>
+    <entry key="installer.action.extract.finished">Extracted successfully</entry>
 
-    <entry key="window.title">%s Installer</entry>
-    <entry key="frame.installing">Installing %s version %s</entry>
+    <entry key="installer.window.title">%s Installer</entry>
+    <entry key="installer.frame.installing">Installing %s version %s</entry>
 
-    <entry key="installation.complete">Installation Complete</entry>
-    <entry key="installation.cancelled">Installation Cancelled</entry>
+    <entry key="installer.installation.complete">Installation Complete</entry>
+    <entry key="installer.installation.cancelled">Installation Cancelled</entry>
 
-    <entry key="target.error.notdirectory">The specified path needs to be a directory</entry>
-    <entry key="target.error.directory.notempty">There are already files in the target directory</entry>
-    <entry key="target.error.directory.doesntexist.critical">The specified directory does not exist</entry>
-    <entry key="target.error.directory.doesntexist.create">The specified directory does not exist&lt;br&gt;It will be created</entry>
-    <entry key="target.error.missingprofile">The directory is missing a launcher profile. Please run the Minecraft launcher first</entry>
+    <entry key="installer.target.error.notdirectory">The specified path needs to be a directory</entry>
+    <entry key="installer.target.error.directory.notempty">There are already files in the target directory</entry>
+    <entry key="installer.target.error.directory.doesntexist.critical">The specified directory does not exist</entry>
+    <entry key="installer.target.error.directory.doesntexist.create">The specified directory does not exist&lt;br&gt;It will be created</entry>
+    <entry key="installer.target.error.missingprofile">The directory is missing a launcher profile. Please run the Minecraft launcher first</entry>
 </properties>


### PR DESCRIPTION
Support translations through resource bundles.
By default the locale is set to the JVM's default locale (falling back to English), and once changed in the dropdown, it will be saved in the user's MC directory under (a hidden) `.neoforge_installer.properties` file.  

The translations will be done through Crowdin, the same way we have it set up for the NeoForge repository.