### PR TITLE
Fix LocalSource detection not handling top level directories.

### DIFF
--- a/src/main/java/net/minecraftforge/installer/DownloadUtils.java
+++ b/src/main/java/net/minecraftforge/installer/DownloadUtils.java
@@ -435,9 +435,9 @@ public class DownloadUtils {
         @Nullable
         static LocalSource walkFromLibs(Path source) {
             source = source.getParent();
-            if (source == null || !source.getFileName().toString().equals("libs")) return null;
+            if (source == null || source.getFileName() == null || !source.getFileName().toString().equals("libs")) return null;
             source = source.getParent();
-            if (source == null || !source.getFileName().toString().equals("build")) return null;
+            if (source == null || source.getFileName() == null || !source.getFileName().toString().equals("build")) return null;
             source = source.getParent();
             if (source == null) return null;
 


### PR DESCRIPTION
`Path#getFileName` will return null for top level directories such as `C:\\`.
We can encounter this when the installer is located in either such a top level directory or in a folder named `libs` in said directory.

[Example Log](https://gist.github.com/AterAnimAvis/20ce9efc79753f8d826358c15b2f07f7)