### PR TITLE
Automatically install a server on headless environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 	testImplementation(platform('org.junit:junit-bom:5.7.2'))
 	testImplementation('org.junit.jupiter:junit-jupiter')
     compileOnly 'org.jetbrains:annotations:24.1.0'
-    testInstallerData 'net.neoforged:neoforge:20.4.76-beta:installer'
+    testInstallerData 'net.neoforged:neoforge:21.4.10-beta:installer'
 }
 
 test {

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -15,6 +15,7 @@
  */
 package net.minecraftforge.installer;
 
+import java.awt.GraphicsEnvironment;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -153,6 +154,13 @@ public class SimpleInstaller {
             if (optionSet.has(fatIncludeInstallerLibs) || optionSet.has(fatOffline)) {
                 FatInstallerAction.OPTIONS.add(FatInstallerAction.Options.INSTALLER_LIBS);
             }
+        }
+
+        if (action == null && GraphicsEnvironment.isHeadless()) {
+            monitor.message("No action was specified but headless environment was detected... Installing server");
+            action = Actions.SERVER;
+            target = optionSet.valueOf(serverInstallOption);
+            ServerInstall.serverStarterJar = true;
         }
 
         if (action != null) {


### PR DESCRIPTION
This PR makes the installer automatically install a server on headless environments without needing the `--install-server` option specified. This should reduce user confusion when they try to simply run the jar on a server