### PR TITLE
add a flag to control the hash checking

### DIFF
--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -98,7 +98,7 @@ public class SimpleInstaller {
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"), "Help with this installer");
         OptionSpec<Void> offlineOption = parser.accepts("offline", "Don't attempt any network calls");
         OptionSpec<Void> debugOption = parser.accepts("debug", "Run in debug mode -- don't delete any files");
-        OptionSpec<Void> skipHashCheckOption = parser.accepts("skipHashCheck", "skips the hash check when verifing outputs");
+        OptionSpec<Void> skipHashCheckOption = parser.accepts("skip-hash-check", "Skips the hash check when verifying outputs");
         OptionSpec<URL> mirrorOption = parser.accepts("mirror", "Use a specific mirror URL").withRequiredArg().ofType(URL.class);
         OptionSet optionSet = parser.parse(args);
 

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -53,6 +53,7 @@ public class SimpleInstaller {
     public static boolean headless = false;
     public static boolean debug = false;
     public static URL mirror = null;
+    public static boolean skipHashCheck = false;
 
     public static void main(String[] args) throws IOException, URISyntaxException {
         ProgressCallback monitor;
@@ -97,6 +98,7 @@ public class SimpleInstaller {
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"), "Help with this installer");
         OptionSpec<Void> offlineOption = parser.accepts("offline", "Don't attempt any network calls");
         OptionSpec<Void> debugOption = parser.accepts("debug", "Run in debug mode -- don't delete any files");
+        OptionSpec<Void> skipHashCheckOption = parser.accepts("skipHashCheck", "skips the hash check when verifing outputs");
         OptionSpec<URL> mirrorOption = parser.accepts("mirror", "Use a specific mirror URL").withRequiredArg().ofType(URL.class);
         OptionSet optionSet = parser.parse(args);
 
@@ -109,6 +111,7 @@ public class SimpleInstaller {
         if (optionSet.has(mirrorOption)) {
             mirror = optionSet.valueOf(mirrorOption);
         }
+        skipHashCheck = optionSet.has(skipHashCheckOption);
 
         boolean isOffline = optionSet.has(offlineOption);
         if (Files.isRegularFile(installer.toPath())) {

--- a/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
+++ b/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
@@ -275,6 +275,10 @@ public class PostProcessors {
                             String sha = DownloadUtils.getSha1(artifact);
                             if (sha.equals(e.getValue())) {
                                 log("  Output: " + e.getKey() + " Checksum Validated: " + sha);
+                            } else if (SimpleInstaller.skipHashCheck) {
+                                log("    " + e.getKey());
+                                log("      Expected: " + e.getValue());
+                                log("      Actual:   " + sha);
                             } else {
                                 err.append("\n    ").append(e.getKey())
                                         .append("\n      Expected: ").append(e.getValue())


### PR DESCRIPTION
Address the compatibility issue with zlib-ng-compat, which is now shipped in place of zlib in various Linux distros. This change introduces an option to disable hash mismatches reported on processors.
I plan to integrate it with the [ForgeWrapper](https://github.com/ZekerZhayard/ForgeWrapper).
