### PR TITLE
Add various CLI options for custom Launcher use-cases

### DIFF
--- a/proguard.pro
+++ b/proguard.pro
@@ -1,4 +1,4 @@
-#-dontoptimize
+-dontoptimize
 -dontobfuscate
 #-dontpreverify
 -dontwarn javax.annotation.**

--- a/proguard.pro
+++ b/proguard.pro
@@ -1,4 +1,4 @@
--dontoptimize
+#-dontoptimize
 -dontobfuscate
 #-dontpreverify
 -dontwarn javax.annotation.**

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -96,8 +96,10 @@ public class SimpleInstaller {
         OptionSpec<Void> fatIncludeInstallerLibs = parser.acceptsAll(Arrays.asList("fat-include-installer-libs"), "Include the installer libraries in the fat installer").availableIf(fatInstallerOption);
         OptionSpec<Void> fatOffline = parser.acceptsAll(Arrays.asList("fat-offline", "gen-offline", "generate-offline", "gf"), "Generate an online fat installer");
 
-        OptionSpec<File> librariesFolderArg = parser.accepts("libraries", "Folder used to store downloaded libraries").withOptionalArg().ofType(File.class);
-        OptionSpec<File> versionsFolderArg = parser.accepts("versions", "Folder used to store downloaded Minecraft versions").withOptionalArg().ofType(File.class);
+        OptionSpec<File> librariesFolderArg = parser.accepts("libraries", "Folder used to store downloaded libraries").availableIf(clientInstallOption, serverInstallOption).withOptionalArg().ofType(File.class);
+        OptionSpec<File> versionsFolderArg = parser.accepts("versions", "Folder used to store downloaded Minecraft versions").availableIf(clientInstallOption).withOptionalArg().ofType(File.class);
+        OptionSpec<Void> skipLauncherProfileOption = parser.accepts("skip-vanilla-launcher-profile", "Does not add a profile to the Vanilla launcher").availableIf(clientInstallOption);
+        OptionSpec<File> mergedVersionJsonFileArg = parser.accepts("version-json-out", "Writes a merged copy of the Vanilla launcher version.json describing how to launch the game to the given path.").availableIf(clientInstallOption).withOptionalArg().ofType(File.class);
 
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"), "Help with this installer");
         OptionSpec<Void> offlineOption = parser.accepts("offline", "Don't attempt any network calls");
@@ -151,6 +153,8 @@ public class SimpleInstaller {
             target = optionSet.valueOf(clientInstallOption);
             ClientInstall.librariesDir = optionSet.valueOf(librariesFolderArg);
             ClientInstall.versionsDir = optionSet.valueOf(versionsFolderArg);
+            ClientInstall.skipLauncherProfile = optionSet.has(skipLauncherProfileOption);
+            ClientInstall.mergedVersionJsonFile = optionSet.valueOf(mergedVersionJsonFileArg);
         } else if (optionSet.has(fatInstallerOption) || optionSet.has(fatOffline)) {
             action = Actions.FAT_INSTALLER;
             target = optionSet.valueOf(fatInstallerOption);

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -98,7 +98,7 @@ public class SimpleInstaller {
 
         OptionSpec<File> librariesFolderArg = parser.accepts("libraries", "Folder used to store downloaded libraries").availableIf(clientInstallOption, serverInstallOption).withOptionalArg().ofType(File.class);
         OptionSpec<File> versionsFolderArg = parser.accepts("versions", "Folder used to store downloaded Minecraft versions").availableIf(clientInstallOption).withOptionalArg().ofType(File.class);
-        OptionSpec<Void> noLauncherProfileOption = parser.accepts("no-create-minecraft-launcher-profile", "Does not add a profile to the official Minecraft Launcher").availableIf(clientInstallOption);
+        OptionSpec<Void> noLauncherProfileOption = parser.accepts("no-minecraft-launcher-profile", "Does not add a profile to the official Minecraft Launcher").availableIf(clientInstallOption);
         OptionSpec<File> mergedVersionJsonFileArg = parser.accepts("write-merged-version-json", "Writes a merged copy of the Vanilla launcher version.json describing how to launch the game to the given path.").availableIf(clientInstallOption).withOptionalArg().ofType(File.class);
         OptionSpec<Void> noDownloadLibrariesOption = parser.accepts("no-download-libraries", "Do not download any libraries that aren't necessary for the installer itself");
 

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -39,6 +39,7 @@ import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import net.minecraftforge.installer.actions.Actions;
+import net.minecraftforge.installer.actions.ClientInstall;
 import net.minecraftforge.installer.actions.FatInstallerAction;
 import net.minecraftforge.installer.actions.ProgressCallback;
 import net.minecraftforge.installer.actions.ServerInstall;
@@ -95,6 +96,9 @@ public class SimpleInstaller {
         OptionSpec<Void> fatIncludeInstallerLibs = parser.acceptsAll(Arrays.asList("fat-include-installer-libs"), "Include the installer libraries in the fat installer").availableIf(fatInstallerOption);
         OptionSpec<Void> fatOffline = parser.acceptsAll(Arrays.asList("fat-offline", "gen-offline", "generate-offline", "gf"), "Generate an online fat installer");
 
+        OptionSpec<File> librariesFolderArg = parser.accepts("libraries", "Folder used to store downloaded libraries").withOptionalArg().ofType(File.class);
+        OptionSpec<File> versionsFolderArg = parser.accepts("versions", "Folder used to store downloaded Minecraft versions").withOptionalArg().ofType(File.class);
+
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"), "Help with this installer");
         OptionSpec<Void> offlineOption = parser.accepts("offline", "Don't attempt any network calls");
         OptionSpec<Void> debugOption = parser.accepts("debug", "Run in debug mode -- don't delete any files");
@@ -141,9 +145,12 @@ public class SimpleInstaller {
             action = Actions.SERVER;
             target = optionSet.valueOf(serverInstallOption);
             ServerInstall.serverStarterJar = optionSet.has(serverStarterOption);
+            ServerInstall.librariesDir = optionSet.valueOf(librariesFolderArg);
         } else if (optionSet.has(clientInstallOption)) {
             action = Actions.CLIENT;
             target = optionSet.valueOf(clientInstallOption);
+            ClientInstall.librariesDir = optionSet.valueOf(librariesFolderArg);
+            ClientInstall.versionsDir = optionSet.valueOf(versionsFolderArg);
         } else if (optionSet.has(fatInstallerOption) || optionSet.has(fatOffline)) {
             action = Actions.FAT_INSTALLER;
             target = optionSet.valueOf(fatInstallerOption);
@@ -179,6 +186,7 @@ public class SimpleInstaller {
                     monitor.stage("You can delete this installer file now if you wish");
                 }
             } catch (Throwable e) {
+                e.printStackTrace();
                 monitor.stage("A problem installing was detected, install cannot continue");
                 System.exit(1);
             }
@@ -207,6 +215,7 @@ public class SimpleInstaller {
             InstallerPanel panel = new InstallerPanel(getMCDir(), profile, installer);
             panel.run(monitor);
         } catch (Throwable e) {
+            e.printStackTrace();
             JOptionPane.showMessageDialog(null, "Something went wrong while installing.<br />Check log for more details:<br/>" + e.toString(), "Error", JOptionPane.ERROR_MESSAGE);
         }
     }

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -98,9 +98,9 @@ public class SimpleInstaller {
 
         OptionSpec<File> librariesFolderArg = parser.accepts("libraries", "Folder used to store downloaded libraries").availableIf(clientInstallOption, serverInstallOption).withOptionalArg().ofType(File.class);
         OptionSpec<File> versionsFolderArg = parser.accepts("versions", "Folder used to store downloaded Minecraft versions").availableIf(clientInstallOption).withOptionalArg().ofType(File.class);
-        OptionSpec<Void> skipLauncherProfileOption = parser.accepts("skip-vanilla-launcher-profile", "Does not add a profile to the Vanilla launcher").availableIf(clientInstallOption);
-        OptionSpec<File> mergedVersionJsonFileArg = parser.accepts("version-json-out", "Writes a merged copy of the Vanilla launcher version.json describing how to launch the game to the given path.").availableIf(clientInstallOption).withOptionalArg().ofType(File.class);
-        OptionSpec<Void> skipLibrariesDownloadArg = parser.accepts("skip-libraries-download", "Do not download any libraries that aren't necessary for the installer itself.");
+        OptionSpec<Void> noLauncherProfileOption = parser.accepts("no-create-minecraft-launcher-profile", "Does not add a profile to the official Minecraft Launcher").availableIf(clientInstallOption);
+        OptionSpec<File> mergedVersionJsonFileArg = parser.accepts("write-merged-version-json", "Writes a merged copy of the Vanilla launcher version.json describing how to launch the game to the given path.").availableIf(clientInstallOption).withOptionalArg().ofType(File.class);
+        OptionSpec<Void> noDownloadLibrariesOption = parser.accepts("no-download-libraries", "Do not download any libraries that aren't necessary for the installer itself");
 
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"), "Help with this installer");
         OptionSpec<Void> offlineOption = parser.accepts("offline", "Don't attempt any network calls");
@@ -149,15 +149,15 @@ public class SimpleInstaller {
             target = optionSet.valueOf(serverInstallOption);
             ServerInstall.serverStarterJar = optionSet.has(serverStarterOption);
             ServerInstall.librariesDir = optionSet.valueOf(librariesFolderArg);
-            ServerInstall.skipLibrariesDownload = optionSet.has(skipLibrariesDownloadArg);
+            ServerInstall.skipLibrariesDownload = optionSet.has(noDownloadLibrariesOption);
         } else if (optionSet.has(clientInstallOption)) {
             action = Actions.CLIENT;
             target = optionSet.valueOf(clientInstallOption);
             ClientInstall.librariesDir = optionSet.valueOf(librariesFolderArg);
             ClientInstall.versionsDir = optionSet.valueOf(versionsFolderArg);
-            ClientInstall.skipLauncherProfile = optionSet.has(skipLauncherProfileOption);
+            ClientInstall.skipLauncherProfile = optionSet.has(noLauncherProfileOption);
             ClientInstall.mergedVersionJsonFile = optionSet.valueOf(mergedVersionJsonFileArg);
-            ClientInstall.skipLibrariesDownload = optionSet.has(skipLibrariesDownloadArg);
+            ClientInstall.skipLibrariesDownload = optionSet.has(noDownloadLibrariesOption);
         } else if (optionSet.has(fatInstallerOption) || optionSet.has(fatOffline)) {
             action = Actions.FAT_INSTALLER;
             target = optionSet.valueOf(fatInstallerOption);

--- a/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
+++ b/src/main/java/net/minecraftforge/installer/SimpleInstaller.java
@@ -100,6 +100,7 @@ public class SimpleInstaller {
         OptionSpec<File> versionsFolderArg = parser.accepts("versions", "Folder used to store downloaded Minecraft versions").availableIf(clientInstallOption).withOptionalArg().ofType(File.class);
         OptionSpec<Void> skipLauncherProfileOption = parser.accepts("skip-vanilla-launcher-profile", "Does not add a profile to the Vanilla launcher").availableIf(clientInstallOption);
         OptionSpec<File> mergedVersionJsonFileArg = parser.accepts("version-json-out", "Writes a merged copy of the Vanilla launcher version.json describing how to launch the game to the given path.").availableIf(clientInstallOption).withOptionalArg().ofType(File.class);
+        OptionSpec<Void> skipLibrariesDownloadArg = parser.accepts("skip-libraries-download", "Do not download any libraries that aren't necessary for the installer itself.");
 
         OptionSpec<Void> helpOption = parser.acceptsAll(Arrays.asList("h", "help"), "Help with this installer");
         OptionSpec<Void> offlineOption = parser.accepts("offline", "Don't attempt any network calls");
@@ -148,6 +149,7 @@ public class SimpleInstaller {
             target = optionSet.valueOf(serverInstallOption);
             ServerInstall.serverStarterJar = optionSet.has(serverStarterOption);
             ServerInstall.librariesDir = optionSet.valueOf(librariesFolderArg);
+            ServerInstall.skipLibrariesDownload = optionSet.has(skipLibrariesDownloadArg);
         } else if (optionSet.has(clientInstallOption)) {
             action = Actions.CLIENT;
             target = optionSet.valueOf(clientInstallOption);
@@ -155,6 +157,7 @@ public class SimpleInstaller {
             ClientInstall.versionsDir = optionSet.valueOf(versionsFolderArg);
             ClientInstall.skipLauncherProfile = optionSet.has(skipLauncherProfileOption);
             ClientInstall.mergedVersionJsonFile = optionSet.valueOf(mergedVersionJsonFileArg);
+            ClientInstall.skipLibrariesDownload = optionSet.has(skipLibrariesDownloadArg);
         } else if (optionSet.has(fatInstallerOption) || optionSet.has(fatOffline)) {
             action = Actions.FAT_INSTALLER;
             target = optionSet.valueOf(fatInstallerOption);

--- a/src/main/java/net/minecraftforge/installer/actions/Action.java
+++ b/src/main/java/net/minecraftforge/installer/actions/Action.java
@@ -18,7 +18,9 @@ package net.minecraftforge.installer.actions;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.swing.JOptionPane;
 import net.minecraftforge.installer.DownloadUtils;
@@ -61,7 +63,13 @@ public abstract class Action {
         return profile.getMirror() != null && profile.getMirror().isAdvertised() ? String.format(SimpleInstaller.headless ? "Data kindly mirrored by %2$s at %1$s" : "<html><a href=\'%s\'>Data kindly mirrored by %s</a></html>", profile.getMirror().getHomepage(), profile.getMirror().getName()) : null;
     }
 
-    protected boolean downloadLibraries(File librariesDir, Predicate<String> optionals, List<File> additionalLibDirs) throws ActionCanceledException {
+    public enum LibraryCategory {
+        VANILLA,
+        NEOFORGE,
+        INSTALLER
+    }
+
+    protected boolean downloadLibraries(File librariesDir, Predicate<String> optionals, List<File> additionalLibDirs, Set<LibraryCategory> categories) throws ActionCanceledException {
         monitor.start("Downloading libraries");
         String userHome = System.getProperty("user.home");
         if (userHome != null && !userHome.isEmpty()) {
@@ -73,8 +81,18 @@ public abstract class Action {
         monitor.message(String.format("Found %d additional library directories", additionalLibDirs.size()));
 
         List<Library> libraries = new ArrayList<>();
-        libraries.addAll(Arrays.asList(version.getLibraries()));
-        libraries.addAll(Arrays.asList(processors.getLibraries()));
+        if (categories.contains(LibraryCategory.VANILLA)) {
+            libraries.addAll(Arrays.asList(version.getLibraries()));
+        }
+        if (categories.contains(LibraryCategory.NEOFORGE)) {
+            libraries.addAll(Arrays.asList(profile.getLibraries()));
+        }
+        if (categories.contains(LibraryCategory.INSTALLER)) {
+            libraries.addAll(Arrays.asList(processors.getLibraries()));
+        }
+
+        Set<String> duplicates = new HashSet<>();
+        libraries.removeIf(library -> !duplicates.add(library.getDownloads() == null ? null : library.getDownloads().getArtifact().getPath()));
 
         StringBuilder output = new StringBuilder();
         monitor.getStepProgress().setMaxProgress(libraries.size());
@@ -100,10 +118,6 @@ public abstract class Action {
 
     protected int downloadedCount() {
         return grabbed.size();
-    }
-
-    protected int getTaskCount() {
-        return profile.getLibraries().length + processors.getTaskCount();
     }
 
     protected void checkCancel() throws ActionCanceledException {

--- a/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
@@ -314,7 +314,7 @@ public class ClientInstall extends Action {
         }
 
         List<JsonObject> result = new ArrayList<>();
-        JsonPrimitive inheritsFrom = manifest.getAsJsonPrimitive("inheritsFrom");
+        JsonPrimitive inheritsFrom = (JsonPrimitive) manifest.remove("inheritsFrom");
         if (inheritsFrom != null) {
             result.addAll(loadVersionManifests(versionsDir, inheritsFrom.getAsString()));
         }

--- a/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
@@ -15,28 +15,45 @@
  */
 package net.minecraftforge.installer.actions;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.function.Predicate;
+import com.google.gson.JsonPrimitive;
 import net.minecraftforge.installer.json.InstallV1;
 import net.minecraftforge.installer.json.Util;
 import net.minecraftforge.installer.json.Version;
 import net.minecraftforge.installer.json.Version.Download;
 import net.minecraftforge.installer.ui.TranslatedMessage;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
 public class ClientInstall extends Action {
 
+    public static boolean skipLibrariesDownload;
     public static File librariesDir;
     public static File versionsDir;
+    public static boolean skipLauncherProfile;
+    public static File mergedVersionJsonFile;
 
     public ClientInstall(InstallV1 profile, ProgressCallback monitor) {
         super(profile, monitor, true);
@@ -51,7 +68,7 @@ public class ClientInstall extends Action {
 
         File launcherProfiles = new File(target, "launcher_profiles.json");
         File launcherProfilesMS = new File(target, "launcher_profiles_microsoft_store.json");
-        if (!launcherProfiles.exists() && !launcherProfilesMS.exists()) {
+        if (!skipLauncherProfile && !launcherProfiles.exists() && !launcherProfilesMS.exists()) {
             error("There is no minecraft launcher profile in \"" + target + "\", you need to run the launcher first!");
             return false;
         }
@@ -68,17 +85,19 @@ public class ClientInstall extends Action {
         checkCancel();
 
         // Extract version json
-        monitor.stage("Extracting json");
-        try (InputStream stream = Util.class.getResourceAsStream(profile.getJson())) {
-            File json = new File(versionsDir, profile.getVersion() + '/' + profile.getVersion() + ".json");
-            json.getParentFile().mkdirs();
-            Files.copy(stream, json.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
-            error("  Failed to extract");
-            e.printStackTrace();
-            return false;
+        if (!skipLauncherProfile) {
+            monitor.stage("Extracting json");
+            try (InputStream stream = Util.class.getResourceAsStream(profile.getJson())) {
+                File json = new File(versionsDir, profile.getVersion() + '/' + profile.getVersion() + ".json");
+                json.getParentFile().mkdirs();
+                Files.copy(stream, json.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException e) {
+                error("  Failed to extract");
+                e.printStackTrace();
+                return false;
+            }
+            checkCancel();
         }
-        checkCancel();
 
         // Download Vanilla main jar/json
         monitor.stage("Considering minecraft client jar");
@@ -101,6 +120,12 @@ public class ClientInstall extends Action {
                 return false;
             }
 
+            // Now is a perfect time to write the merged JSON file since we just downloaded the parent JSON
+            if (mergedVersionJsonFile != null) {
+                monitor.stage("Writing merged version JSON");
+                writeMergedJson(versionsDir, mergedVersionJsonFile);
+            }
+
             Download client = vanilla.getDownload("client");
             if (client == null) {
                 error("Failed to download minecraft client, info missing from manifest: " + versionJson);
@@ -119,7 +144,7 @@ public class ClientInstall extends Action {
         }
 
         // Download Libraries
-        if (!downloadLibraries(librariesDir, optionals, new ArrayList<>()))
+        if (!downloadLibraries(librariesDir, optionals, new ArrayList<>(), skipLibrariesDownload ? EnumSet.of(LibraryCategory.INSTALLER) : EnumSet.allOf(LibraryCategory.class)))
             return false;
         checkCancel();
 
@@ -158,20 +183,158 @@ public class ClientInstall extends Action {
 
         checkCancel();
 
-        monitor.stage("Injecting profile");
-        if (launcherProfiles.exists() && !injectProfile(launcherProfiles))
-            return false;
-        if (launcherProfilesMS.exists() && !injectProfile(launcherProfilesMS))
-            return false;
+        if (!skipLauncherProfile) {
+            monitor.stage("Injecting profile");
+            if (launcherProfiles.exists() && !injectProfile(launcherProfiles))
+                return false;
+            if (launcherProfilesMS.exists() && !injectProfile(launcherProfilesMS))
+                return false;
+        }
 
         return true;
     }
 
+    private void writeMergedJson(File versionsDir, File mergedVersionJsonFile) {
+
+        JsonObject nfManifest;
+        try (InputStream stream = Util.class.getResourceAsStream(profile.getJson())) {
+            nfManifest = JsonParser.parseReader(new InputStreamReader(stream, StandardCharsets.UTF_8)).getAsJsonObject();
+        } catch (IOException e) {
+            error("Failed to read embedded version JSON");
+            e.printStackTrace();
+            return;
+        }
+
+        // Merge extended version manifests into this one
+        JsonPrimitive inheritsFrom = nfManifest.getAsJsonPrimitive("inheritsFrom");
+        if (inheritsFrom != null) {
+            List<JsonObject> manifests;
+            try {
+                manifests = loadVersionManifests(versionsDir, inheritsFrom.getAsString());
+            } catch (IOException e) {
+                error("Failed to read parent manifests");
+                e.printStackTrace();
+                return;
+            }
+            manifests.add(nfManifest);
+
+            // Start with the first, then layer everything else on top. We consider these uncached and free to manipulate
+            JsonObject baseManifest = manifests.get(0);
+            Map<String, JsonObject> baseLibraryIndex = null;
+
+            for (int i = 1; i < manifests.size(); i++) {
+                JsonObject overlayManifest = manifests.get(i);
+                for (Map.Entry<String, JsonElement> entry : overlayManifest.entrySet()) {
+                    JsonElement baseValue = baseManifest.get(entry.getKey());
+                    if (baseValue != null) {
+                        // Special-case merge logic for arguments and libraries
+                        switch (entry.getKey()) {
+                            case "arguments":
+                                mergeArguments(baseValue, entry.getValue());
+                                continue;
+                            case "libraries":
+                                if (baseLibraryIndex == null) {
+                                    JsonArray baseLibraries = baseValue.getAsJsonArray();
+                                    baseLibraryIndex = new HashMap<>(baseLibraries.size());
+                                    for (JsonElement baseLibrary : baseLibraries) {
+                                        JsonObject baseLibraryObj = baseLibrary.getAsJsonObject();
+                                        String libraryName = baseLibraryObj.getAsJsonPrimitive("name").getAsString();
+                                        baseLibraryIndex.put(libraryName, baseLibraryObj);
+                                    }
+                                }
+                                mergeLibraries(baseValue, entry.getValue(), baseLibraryIndex);
+                                continue;
+                        }
+                    }
+
+                    baseManifest.add(entry.getKey(), entry.getValue());
+                }
+            }
+            nfManifest = baseManifest;
+        }
+
+        // Write the merged version manifest
+        File parent = mergedVersionJsonFile.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(mergedVersionJsonFile))) {
+            Util.GSON.toJson(nfManifest, new OutputStreamWriter(out, StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            error("Failed to read parent manifests");
+            e.printStackTrace();
+            return;
+        }
+
+    }
+
+    private void mergeLibraries(JsonElement base, JsonElement overlay, Map<String, JsonObject> baseLibraryIndex) {
+        JsonArray baseLibraries = base.getAsJsonArray();
+        JsonArray overlayLibraries = overlay.getAsJsonArray();
+
+        for (JsonElement overlayLibrary : overlayLibraries) {
+            JsonObject overlayLibraryObj = overlayLibrary.getAsJsonObject();
+            String name = overlayLibraryObj.getAsJsonPrimitive("name").getAsString();
+            JsonObject baseLibraryObj = baseLibraryIndex.get(name);
+            if (baseLibraryObj != null) {
+                // Overrides an existing library
+                for (Map.Entry<String, JsonElement> entry : overlayLibraryObj.entrySet()) {
+                    baseLibraryObj.add(entry.getKey(), entry.getValue());
+                }
+            } else {
+                // New library
+                baseLibraries.add(overlayLibraryObj);
+                baseLibraryIndex.put(name, overlayLibraryObj);
+            }
+        }
+    }
+
+    private void mergeArguments(JsonElement base, JsonElement overlay) {
+        JsonObject baseObject = base.getAsJsonObject();
+
+        // Really just "game" and "jvm" but the logic is the same (simple append)
+        for (Map.Entry<String, JsonElement> entry : overlay.getAsJsonObject().entrySet()) {
+            if (!baseObject.has(entry.getKey())) {
+                baseObject.add(entry.getKey(), entry.getValue());
+            } else {
+                baseObject.getAsJsonArray(entry.getKey()).addAll(entry.getValue().getAsJsonArray());
+            }
+        }
+    }
+
+    // Returns the inherited manifests first
+    private static List<JsonObject> loadVersionManifests(File versionsDir, String versionId) throws IOException {
+        // Read back the version manifest and get the startup arguments
+        File manifestPath = new File(versionsDir, versionId + "/" + versionId + ".json");
+        JsonObject manifest;
+        try {
+            manifest = readJson(manifestPath);
+        } catch (IOException e) {
+            throw new IOException("Failed to read launcher profile " + manifestPath, e);
+        }
+
+        List<JsonObject> result = new ArrayList<>();
+        JsonPrimitive inheritsFrom = manifest.getAsJsonPrimitive("inheritsFrom");
+        if (inheritsFrom != null) {
+            result.addAll(loadVersionManifests(versionsDir, inheritsFrom.getAsString()));
+        }
+
+        result.add(manifest);
+
+        return result;
+    }
+
+    private static JsonObject readJson(File file) throws IOException {
+        try (InputStream stream = new BufferedInputStream(new FileInputStream(file))) {
+            return JsonParser.parseReader(new InputStreamReader(stream, StandardCharsets.UTF_8)).getAsJsonObject();
+        }
+    }
+
     private boolean injectProfile(File target) {
         try {
-            JsonObject json = null;
-            try (InputStream stream = new FileInputStream(target)) {
-                json = JsonParser.parseReader(new InputStreamReader(stream, StandardCharsets.UTF_8)).getAsJsonObject();
+            JsonObject json;
+            try {
+                json = readJson(target);
             } catch (IOException e) {
                 error("Failed to read " + target);
                 e.printStackTrace();

--- a/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ClientInstall.java
@@ -34,6 +34,10 @@ import net.minecraftforge.installer.json.Version.Download;
 import net.minecraftforge.installer.ui.TranslatedMessage;
 
 public class ClientInstall extends Action {
+
+    public static File librariesDir;
+    public static File versionsDir;
+
     public ClientInstall(InstallV1 profile, ProgressCallback monitor) {
         super(profile, monitor, true);
     }
@@ -52,16 +56,21 @@ public class ClientInstall extends Action {
             return false;
         }
 
-        File versionRoot = new File(target, "versions");
-        File librariesDir = new File(target, "libraries");
-        librariesDir.mkdir();
+        if (versionsDir == null) {
+            versionsDir = new File(target, "versions");
+        }
+        if (librariesDir == null) {
+            librariesDir = new File(target, "libraries");
+        }
+        librariesDir.mkdirs();
+        versionsDir.mkdirs();
 
         checkCancel();
 
         // Extract version json
         monitor.stage("Extracting json");
         try (InputStream stream = Util.class.getResourceAsStream(profile.getJson())) {
-            File json = new File(versionRoot, profile.getVersion() + '/' + profile.getVersion() + ".json");
+            File json = new File(versionsDir, profile.getVersion() + '/' + profile.getVersion() + ".json");
             json.getParentFile().mkdirs();
             Files.copy(stream, json.toPath(), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
@@ -73,7 +82,7 @@ public class ClientInstall extends Action {
 
         // Download Vanilla main jar/json
         monitor.stage("Considering minecraft client jar");
-        File versionVanilla = new File(versionRoot, profile.getMinecraft());
+        File versionVanilla = new File(versionsDir, profile.getMinecraft());
         if (!versionVanilla.mkdirs() && !versionVanilla.isDirectory()) {
             if (!versionVanilla.delete()) {
                 error("There was a problem with the launcher version data. You will need to clear " + versionVanilla + " manually.");

--- a/src/main/java/net/minecraftforge/installer/actions/FatInstallerAction.java
+++ b/src/main/java/net/minecraftforge/installer/actions/FatInstallerAction.java
@@ -85,6 +85,7 @@ public class FatInstallerAction extends Action {
                     libraries.addAll(Arrays.asList(version.getLibraries()));
                 }
                 if (OPTIONS.contains(Options.INSTALLER_LIBS)) {
+                    libraries.addAll(Arrays.asList(profile.getLibraries()));
                     libraries.addAll(Arrays.asList(processors.getLibraries()));
 
                     monitor.stage("Downloading server starter jar");

--- a/src/main/java/net/minecraftforge/installer/actions/FatInstallerAction.java
+++ b/src/main/java/net/minecraftforge/installer/actions/FatInstallerAction.java
@@ -83,9 +83,9 @@ public class FatInstallerAction extends Action {
                 final List<Version.Library> libraries = new ArrayList<>();
                 if (OPTIONS.contains(Options.MC_LIBS)) {
                     libraries.addAll(Arrays.asList(version.getLibraries()));
+                    libraries.addAll(Arrays.asList(profile.getLibraries()));
                 }
                 if (OPTIONS.contains(Options.INSTALLER_LIBS)) {
-                    libraries.addAll(Arrays.asList(profile.getLibraries()));
                     libraries.addAll(Arrays.asList(processors.getLibraries()));
 
                     monitor.stage("Downloading server starter jar");

--- a/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
+++ b/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java
@@ -26,10 +26,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
@@ -48,28 +51,30 @@ public class PostProcessors {
     private final InstallV1 profile;
     private final boolean isClient;
     private final ProgressCallback monitor;
-    private final boolean hasTasks;
     private final Map<String, String> data;
     private final List<Processor> processors;
+    private final Library[] libraries;
 
     public PostProcessors(InstallV1 profile, boolean isClient, ProgressCallback monitor) {
         this.profile = profile;
         this.isClient = isClient;
         this.monitor = monitor;
         this.processors = profile.getProcessors(isClient ? "client" : "server");
-        this.hasTasks = !this.processors.isEmpty();
         this.data = profile.getData(isClient);
+
+        // Filter the list of libraries by the classpath requirements of the processors
+        Set<Artifact> requiredClasspath = new HashSet<>(processors.size()); // Likely an under-estimate
+        for (Processor processor : processors) {
+            Collections.addAll(requiredClasspath, processor.getClasspath());
+        }
+
+        this.libraries = Arrays.stream(profile.getLibraries())
+                .filter(l -> requiredClasspath.contains(l.getName()))
+                .toArray(Library[]::new);
     }
 
     public Library[] getLibraries() {
-        return hasTasks ? profile.getLibraries() : new Library[0];
-    }
-
-    public int getTaskCount() {
-        return hasTasks ? 0
-                : profile.getLibraries().length +
-                        processors.size() +
-                        profile.getData(isClient).size();
+        return libraries;
     }
 
     public boolean process(File librariesDir, File minecraft, File root, File installer) {

--- a/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
@@ -17,6 +17,7 @@ package net.minecraftforge.installer.actions;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +104,8 @@ public class ServerInstall extends Action {
         if (mcLibDir.exists()) {
             libDirs.add(mcLibDir);
         }
-        if (!downloadLibraries(librariesDir, optionals, libDirs))
+        // Don't download Vanilla libraries since they're already bundled in the server fatjar we'll extract anyway
+        if (!downloadLibraries(librariesDir, optionals, libDirs, EnumSet.of(LibraryCategory.NEOFORGE, LibraryCategory.INSTALLER)))
             return false;
 
         checkCancel();

--- a/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
@@ -32,6 +32,7 @@ import net.minecraftforge.installer.ui.TranslatedMessage;
 
 public class ServerInstall extends Action {
     public static boolean serverStarterJar;
+    public static File librariesDir;
 
     private final List<Artifact> grabbed = new ArrayList<>();
 
@@ -46,10 +47,11 @@ public class ServerInstall extends Action {
             return false;
         }
 
-        File librariesDir = new File(target, "libraries");
-        if (!target.exists())
-            target.mkdirs();
-        librariesDir.mkdir();
+        if (librariesDir == null) {
+            librariesDir = new File(target, "libraries");
+        }
+        target.mkdirs();
+        librariesDir.mkdirs();
         if (profile.getMirror() != null && profile.getMirror().isAdvertised())
             monitor.stage(getSponsorMessage());
         checkCancel();

--- a/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
+++ b/src/main/java/net/minecraftforge/installer/actions/ServerInstall.java
@@ -15,13 +15,6 @@
  */
 package net.minecraftforge.installer.actions;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Predicate;
 import net.minecraftforge.installer.DownloadUtils;
 import net.minecraftforge.installer.SimpleInstaller;
 import net.minecraftforge.installer.json.Artifact;
@@ -31,9 +24,19 @@ import net.minecraftforge.installer.json.Version;
 import net.minecraftforge.installer.json.Version.Download;
 import net.minecraftforge.installer.ui.TranslatedMessage;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
 public class ServerInstall extends Action {
     public static boolean serverStarterJar;
     public static File librariesDir;
+    public static boolean skipLibrariesDownload;
 
     private final List<Artifact> grabbed = new ArrayList<>();
 
@@ -105,7 +108,13 @@ public class ServerInstall extends Action {
             libDirs.add(mcLibDir);
         }
         // Don't download Vanilla libraries since they're already bundled in the server fatjar we'll extract anyway
-        if (!downloadLibraries(librariesDir, optionals, libDirs, EnumSet.of(LibraryCategory.NEOFORGE, LibraryCategory.INSTALLER)))
+        Set<LibraryCategory> librarySet;
+        if (skipLibrariesDownload) {
+            librarySet = EnumSet.of(LibraryCategory.INSTALLER);
+        } else {
+            librarySet = EnumSet.of(LibraryCategory.NEOFORGE, LibraryCategory.INSTALLER);
+        }
+        if (!downloadLibraries(librariesDir, optionals, libDirs, librarySet))
             return false;
 
         checkCancel();

--- a/src/main/java/net/minecraftforge/installer/json/Artifact.java
+++ b/src/main/java/net/minecraftforge/installer/json/Artifact.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.io.File;
 import java.lang.reflect.Type;
+import java.util.Objects;
 
 public class Artifact {
     //Descriptor parts: group:name:version[:classifier][@extension]
@@ -101,6 +102,22 @@ public class Artifact {
 
     public String getFilename() {
         return file;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Artifact artifact = (Artifact) o;
+        return Objects.equals(domain, artifact.domain) &&
+                Objects.equals(name, artifact.name) &&
+                Objects.equals(version, artifact.version) &&
+                Objects.equals(classifier, artifact.classifier) &&
+                Objects.equals(ext, artifact.ext);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(domain, name, version, classifier, ext);
     }
 
     @Override


### PR DESCRIPTION
Introduces the following CLI options:

| Option                               | Description                                                                                                                                                                                                         |
|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `--libraries <folder>`               | Overrides the directory where libraries will be downloaded to, and generated files such as the patched Minecraft jar will be stored.                                                                                |
| `--versions <versions>`              | Overrides the directory where the installer looks for Vanilla client jars and stores them if it has to download them.                                                                                               |                                                                                          
| `--no-minecraft-launcher-profile`    | Skips adding a profile to the Vanilla launcher, this also disables the check whether the target directory for a client installation is a valid Vanilla launcher directory.                                          |
| `--write-merged-version-json <path>` | If given, the installer creates a Vanilla Launcher version json for the NeoForge version that is being installed. This JSON file will have no `inheritFrom` fields, and will fully describe how to launch the game. |
| `--no-download-libraries`            | Disables downloading of any libraries beyond the libraries needed to perform the installation.                                                                                                                      |
