### PR TITLE
Skip direct-copying entries starting with `maven/`

### DIFF
--- a/src/main/java/net/minecraftforge/installer/actions/FatInstallerAction.java
+++ b/src/main/java/net/minecraftforge/installer/actions/FatInstallerAction.java
@@ -56,6 +56,8 @@ public class FatInstallerAction extends Action {
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();
                 if (entry.getName().equals("META-INF/MANIFEST.MF")) continue;
+                // These will be downloaded through LocalSource#fromResource()
+                if (entry.getName().startsWith("maven/")) continue;
                 ZipEntry ze = new ZipEntry(entry.getName());
                 out.putNextEntry(ze);
                 copy(in.getInputStream(entry), out);


### PR DESCRIPTION
This PR fixes #48 by teaching `FatInstallerAction` to skip copying JAR entries which begin with `maven/`. The `Downloader` instance will pick artifacts from that directory through `LocalSource#fromResource()`.

This has two side-effects:
- Any artifacts in the original installer's `maven/` that are unused (not declared in the manifests for vanilla and NeoForge) will get skipped over.
- If the artifact under `maven/` has a different checksum from the one declared in the manifests (if there is one), the downloader will reject that stored artifact and download it anew.