### PR TITLE
Properly use the correct path when downloading Libraries

### DIFF
--- a/src/main/java/net/minecraftforge/installer/DownloadUtils.java
+++ b/src/main/java/net/minecraftforge/installer/DownloadUtils.java
@@ -53,7 +53,7 @@ public class DownloadUtils {
 
     public static boolean downloadLibrary(ProgressCallback monitor, Library library, File root, Predicate<String> optional, List<Artifact> grabbed, List<File> additionalLibraryDirs) {
         Artifact artifact = library.getName();
-        File target =  artifact.getLocalPath(root);
+        File target = artifact.getLocalPath(root);
         LibraryDownload download = library.getDownloads() == null ? null : library.getDownloads().getArtifact();
         if (download == null) {
             download = new LibraryDownload();

--- a/src/main/java/net/minecraftforge/installer/DownloadUtils.java
+++ b/src/main/java/net/minecraftforge/installer/DownloadUtils.java
@@ -53,11 +53,13 @@ public class DownloadUtils {
 
     public static boolean downloadLibrary(ProgressCallback monitor, Library library, File root, Predicate<String> optional, List<Artifact> grabbed, List<File> additionalLibraryDirs) {
         Artifact artifact = library.getName();
-        File target = artifact.getLocalPath(root);
+        File target =  artifact.getLocalPath(root);
         LibraryDownload download = library.getDownloads() == null ? null : library.getDownloads().getArtifact();
         if (download == null) {
             download = new LibraryDownload();
             download.setPath(artifact.getPath());
+        } else if (download.getPath() != null) {
+            target = new File(root, download.getPath());
         }
 
         if (!optional.test(library.getName().getDescriptor())) {


### PR DESCRIPTION
When downloading libraries, the system expects the path contained in the library instructions to be used, and not a custom path generated from the artifact identifier name,

Overwrite the default path (from the artifact coordinate) with the path defined in the libraries download instructions.